### PR TITLE
Refactor Region struct

### DIFF
--- a/crates/memory/src/region.rs
+++ b/crates/memory/src/region.rs
@@ -16,27 +16,11 @@ impl Region {
         let rhs_start = rhs.start as u64;
         let rhs_end = rhs_start + (rhs.len - 1) as u64;
 
-        // start of rhs inside self:
-        if rhs_start >= self_start && rhs_start < self_end {
-            return true;
+        if self_start <= rhs_start {
+            self_end >= rhs_start
+        } else {
+            rhs_end >= self_start
         }
-
-        // end of rhs inside self:
-        if rhs_end >= self_start && rhs_end < self_end {
-            return true;
-        }
-
-        // start of self inside rhs:
-        if self_start >= rhs_start && self_start < rhs_end {
-            return true;
-        }
-
-        // end of self inside rhs: XXX is this redundant? i suspect it is but im too tired
-        if self_end >= rhs_start && self_end < rhs_end {
-            return true;
-        }
-
-        false
     }
 }
 

--- a/crates/memory/src/region.rs
+++ b/crates/memory/src/region.rs
@@ -1,3 +1,4 @@
+/// Represents a contiguous region in memory.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Region {
     pub start: u32,
@@ -9,6 +10,7 @@ impl Region {
         Self { start, len }
     }
 
+    /// Checks if this `Region` overlaps with `rhs` `Region`.
     pub fn overlaps(&self, rhs: Region) -> bool {
         let self_start = self.start as u64;
         let self_end = self_start + (self.len - 1) as u64;

--- a/crates/memory/src/region.rs
+++ b/crates/memory/src/region.rs
@@ -7,6 +7,7 @@ pub struct Region {
 
 impl Region {
     pub fn new(start: u32, len: u32) -> Self {
+        assert!(len > 0, "Region cannot have 0 length");
         Self { start, len }
     }
 

--- a/crates/memory/src/region.rs
+++ b/crates/memory/src/region.rs
@@ -5,6 +5,10 @@ pub struct Region {
 }
 
 impl Region {
+    pub fn new(start: u32, len: u32) -> Self {
+        Self { start, len }
+    }
+
     pub fn overlaps(&self, rhs: Region) -> bool {
         let self_start = self.start as u64;
         let self_end = self_start + (self.len - 1) as u64;
@@ -33,5 +37,40 @@ impl Region {
         }
 
         false
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn nonoverlapping() {
+        let r1 = Region::new(0, 10);
+        let r2 = Region::new(10, 10);
+        assert!(!r1.overlaps(r2));
+
+        let r1 = Region::new(10, 10);
+        let r2 = Region::new(0, 10);
+        assert!(!r1.overlaps(r2));
+    }
+
+    #[test]
+    fn overlapping() {
+        let r1 = Region::new(0, 10);
+        let r2 = Region::new(9, 10);
+        assert!(r1.overlaps(r2));
+
+        let r1 = Region::new(0, 10);
+        let r2 = Region::new(2, 5);
+        assert!(r1.overlaps(r2));
+
+        let r1 = Region::new(9, 10);
+        let r2 = Region::new(0, 10);
+        assert!(r1.overlaps(r2));
+
+        let r1 = Region::new(2, 5);
+        let r2 = Region::new(0, 10);
+        assert!(r1.overlaps(r2));
     }
 }


### PR DESCRIPTION
This PR adds some basic sanity tests for `Region` struct. In particular, it covers `Region::overlaps` method with some basic unit tests. It also refactor the logic of the said method (hopefully, it's slightly simpler now). Finally, it adds some rudimentary docs to the struct and its methods.