### PR TITLE
Refactor tests to use proptest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+proptest-regressions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ edition = "2018"
 generate = { path = "crates/generate" }
 memory = { path = "crates/memory" }
 
+[dev-dependencies]
+proptest = "0.9"
+
 [workspace]
 members = [
   "crates/generate",

--- a/crates/generate/src/funcs.rs
+++ b/crates/generate/src/funcs.rs
@@ -5,6 +5,8 @@ use crate::names::Names;
 use crate::types::{anon_lifetime, struct_is_copy};
 
 pub fn define_func(names: &Names, func: &witx::InterfaceFunc) -> TokenStream {
+    let funcname = func.name.as_str();
+
     let ident = names.func(&func.name);
     let ctx_type = names.ctx_type();
     let coretype = func.core_type();
@@ -52,7 +54,7 @@ pub fn define_func(names: &Names, func: &witx::InterfaceFunc) -> TokenStream {
         .map(|_res| quote!(#abi_ret::from(e)))
         .unwrap_or_else(|| quote!(()));
 
-    let error_handling: TokenStream = {
+    let error_handling = |location: &str| -> TokenStream {
         if let Some(tref) = &err_type {
             let abi_ret = match tref.type_().passed_by() {
                 witx::TypePassedBy::Value(atom) => names.atom_type(atom),
@@ -60,6 +62,7 @@ pub fn define_func(names: &Names, func: &witx::InterfaceFunc) -> TokenStream {
             };
             let err_typename = names.type_ref(&tref, anon_lifetime());
             quote! {
+                let e = ::memory::GuestError::InFunc { funcname: #funcname, location: #location, err: Box::new(e) };
                 let err: #err_typename = ::memory::GuestErrorType::from_error(e, ctx);
                 return #abi_ret::from(err);
             }
@@ -73,7 +76,7 @@ pub fn define_func(names: &Names, func: &witx::InterfaceFunc) -> TokenStream {
     let marshal_args = func
         .params
         .iter()
-        .map(|p| marshal_arg(names, p, error_handling.clone()));
+        .map(|p| marshal_arg(names, p, error_handling(p.name.as_str())));
     let trait_args = func.params.iter().map(|param| {
         let name = names.func_param(&param.name);
         match param.tref.type_().passed_by() {
@@ -101,11 +104,11 @@ pub fn define_func(names: &Names, func: &witx::InterfaceFunc) -> TokenStream {
         .results
         .iter()
         .skip(1)
-        .map(|result| marshal_result(names, result, error_handling.clone()));
+        .map(|result| marshal_result(names, result, &error_handling));
     let marshal_rets_pre = marshal_rets.clone().map(|(pre, _post)| pre);
     let marshal_rets_post = marshal_rets.map(|(_pre, post)| post);
 
-    let success = if let Some(err_type) = err_type {
+    let success = if let Some(ref err_type) = err_type {
         let err_typename = names.type_ref(&err_type, anon_lifetime());
         quote! {
             let success:#err_typename = ::memory::GuestErrorType::success();
@@ -243,27 +246,32 @@ fn marshal_arg(
     }
 }
 
-fn marshal_result(
+fn marshal_result<F>(
     names: &Names,
     result: &witx::InterfaceFuncParam,
-    error_handling: TokenStream,
-) -> (TokenStream, TokenStream) {
+    error_handling: F,
+) -> (TokenStream, TokenStream)
+where
+    F: Fn(&str) -> TokenStream,
+{
     let tref = &result.tref;
 
     let write_val_to_ptr = {
         let pointee_type = names.type_ref(tref, anon_lifetime());
         // core type is given func_ptr_binding name.
         let ptr_name = names.func_ptr_binding(&result.name);
+        let ptr_err_handling = error_handling(&format!("{}:result_ptr_mut", result.name.as_str()));
+        let ref_err_handling = error_handling(&format!("{}:result_ref_mut", result.name.as_str()));
         let pre = quote! {
             let mut #ptr_name = match memory.ptr_mut::<#pointee_type>(#ptr_name as u32) {
                 Ok(p) => match p.as_ref_mut() {
                     Ok(r) => r,
                     Err(e) => {
-                        #error_handling
+                        #ref_err_handling
                     }
                 },
                 Err(e) => {
-                    #error_handling
+                    #ptr_err_handling
                 }
             };
         };

--- a/crates/generate/src/funcs.rs
+++ b/crates/generate/src/funcs.rs
@@ -28,7 +28,7 @@ pub fn define_func(names: &Names, func: &witx::InterfaceFunc) -> TokenStream {
     });
 
     let abi_args = quote!(
-            ctx: &mut #ctx_type, memory: ::memory::GuestMemory,
+            ctx: &mut #ctx_type, memory: &mut ::memory::GuestMemory,
             #(#params),*
     );
     let abi_ret = if let Some(ret) = &coretype.ret {

--- a/crates/generate/src/types.rs
+++ b/crates/generate/src/types.rs
@@ -192,13 +192,13 @@ fn define_copy_struct(names: &Names, name: &witx::Id, s: &witx::StructDatatype) 
         quote! {
             #type_::validate(
                 &ptr.cast(#offset).map_err(|e|
-                    ::memory::GuestError::InField{
+                    ::memory::GuestError::InDataField{
                         typename: stringify!(#ident).to_owned(),
                         field: stringify!(#fieldname).to_owned(),
                         err: Box::new(e),
                     })?
                 ).map_err(|e|
-                    ::memory::GuestError::InField {
+                    ::memory::GuestError::InDataField {
                         typename: stringify!(#ident).to_owned(),
                         field: stringify!(#fieldname).to_owned(),
                         err: Box::new(e),
@@ -278,13 +278,13 @@ fn define_ptr_struct(names: &Names, name: &witx::Id, s: &witx::StructDatatype) -
         quote! {
             #type_::validate(
                 &ptr.cast(#offset).map_err(|e|
-                    ::memory::GuestError::InField{
+                    ::memory::GuestError::InDataField{
                         typename: stringify!(#ident).to_owned(),
                         field: stringify!(#fieldname).to_owned(),
                         err: Box::new(e),
                     })?
                 ).map_err(|e|
-                    ::memory::GuestError::InField {
+                    ::memory::GuestError::InDataField {
                         typename: stringify!(#ident).to_owned(),
                         field: stringify!(#fieldname).to_owned(),
                         err: Box::new(e),

--- a/crates/memory/src/error.rs
+++ b/crates/memory/src/error.rs
@@ -11,8 +11,15 @@ pub enum GuestError {
     PtrNotAligned(Region, u32),
     #[error("Pointer already borrowed: {0:?}")]
     PtrBorrowed(Region),
-    #[error("In {typename}.{field}:")]
-    InField {
+    #[error("In func {funcname}:{location}:")]
+    InFunc {
+        funcname: &'static str,
+        location: &'static str,
+        #[source]
+        err: Box<GuestError>,
+    },
+    #[error("In data {typename}.{field}:")]
+    InDataField {
         typename: String,
         field: String,
         #[source]

--- a/crates/memory/src/memory.rs
+++ b/crates/memory/src/memory.rs
@@ -26,7 +26,7 @@ impl<'a> GuestMemory<'a> {
     fn contains(&self, r: Region) -> bool {
         r.start < self.len
             && r.len < self.len // make sure next clause doesnt underflow
-            && r.start < (self.len - r.len)
+            && r.start <= (self.len - r.len)
     }
 
     pub fn ptr<T: GuestType>(&'a self, at: u32) -> Result<GuestPtr<'a, T>, GuestError> {

--- a/crates/memory/src/region.rs
+++ b/crates/memory/src/region.rs
@@ -7,10 +7,10 @@ pub struct Region {
 impl Region {
     pub fn overlaps(&self, rhs: Region) -> bool {
         let self_start = self.start as u64;
-        let self_end = ((self_start + self.len as u64) as i64 - 1) as u64;
+        let self_end = self_start + (self.len - 1) as u64;
 
         let rhs_start = rhs.start as u64;
-        let rhs_end = ((rhs_start + rhs.len as u64) as i64 - 1) as u64;
+        let rhs_end = rhs_start + (rhs.len - 1) as u64;
 
         // start of rhs inside self:
         if rhs_start >= self_start && rhs_start < self_end {

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -102,6 +102,7 @@ impl ::memory::GuestErrorType for types::Errno {
         types::Errno::Ok
     }
     fn from_error(e: ::memory::GuestError, ctx: &mut WasiCtx) -> types::Errno {
+        eprintln!("GUEST ERROR: {:?}", e);
         ctx.guest_errors.push(e);
         types::Errno::InvalidArg
     }
@@ -121,14 +122,64 @@ impl HostMemory {
     pub fn len(&self) -> usize {
         self.buffer.len()
     }
-    pub fn pointer_strat(align: u32) -> BoxedStrategy<u32> {
+    pub fn mem_area_strat(align: u32) -> BoxedStrategy<MemArea> {
         prop::num::u32::ANY
             .prop_map(move |p| {
                 let p_aligned = p - (p % align); // Align according to argument
-                p_aligned % 4096 // Put inside memory
+                let ptr = p_aligned % 4096; // Put inside memory
+                MemArea { ptr, len: align }
             })
             .boxed()
     }
+}
+
+#[derive(Debug)]
+struct MemArea {
+    ptr: u32,
+    len: u32,
+}
+
+// This code is a whole lot like the Region::overlaps func thats at the core of the code under
+// test.
+// So, I implemented this one with std::ops::Range so it is less likely I wrote the same bug in two
+// places.
+fn overlapping(a: &MemArea, b: &MemArea) -> bool {
+    // a_range is all elems in A
+    let a_range = std::ops::Range {
+        start: a.ptr,
+        end: a.ptr + a.len - 1,
+    };
+    // b_range is all elems in B
+    let b_range = std::ops::Range {
+        start: b.ptr,
+        end: b.ptr + b.len - 1,
+    };
+    // No element in B is contained in A:
+    for b_elem in b_range.clone() {
+        if a_range.contains(&b_elem) {
+            return true;
+        }
+    }
+    // No element in A is contained in B:
+    for a_elem in a_range {
+        if b_range.contains(&a_elem) {
+            return true;
+        }
+    }
+    return false;
+}
+
+fn non_overlapping_set(areas: &[&MemArea]) -> bool {
+    // A is all areas
+    for (i, a) in areas.iter().enumerate() {
+        // (A, B) is every pair of areas
+        for b in areas[i + 1..].iter() {
+            if overlapping(a, b) {
+                return false;
+            }
+        }
+    }
+    return true;
 }
 
 #[test]
@@ -142,7 +193,7 @@ fn hostmemory_is_aligned() {
 #[derive(Debug)]
 struct BatExercise {
     pub input: u32,
-    pub return_loc: u32,
+    pub return_loc: MemArea,
 }
 
 impl BatExercise {
@@ -156,20 +207,20 @@ impl BatExercise {
             &mut ctx,
             &mut guest_memory,
             self.input as i32,
-            self.return_loc as i32,
+            self.return_loc.ptr as i32,
         );
 
         let return_val: GuestRef<f32> = guest_memory
-            .ptr(self.return_loc)
+            .ptr(self.return_loc.ptr)
             .expect("return loc ptr")
             .as_ref()
             .expect("return val ref");
-        assert_eq!(bat_err, types::Errno::Ok.into());
-        assert_eq!(*return_val, (self.input as f32) * 2.0);
+        assert_eq!(bat_err, types::Errno::Ok.into(), "bat errno");
+        assert_eq!(*return_val, (self.input as f32) * 2.0, "bat return val");
     }
 
     pub fn strat() -> BoxedStrategy<Self> {
-        (prop::num::u32::ANY, HostMemory::pointer_strat(4))
+        (prop::num::u32::ANY, HostMemory::mem_area_strat(4))
             .prop_map(|(input, return_loc)| BatExercise { input, return_loc })
             .boxed()
     }
@@ -195,12 +246,12 @@ fn excuse_strat() -> impl Strategy<Value = types::Excuse> {
 struct BazExercise {
     pub input1: types::Excuse,
     pub input2: types::Excuse,
-    pub input2_loc: u32,
+    pub input2_loc: MemArea,
     pub input3: types::Excuse,
-    pub input3_loc: u32,
+    pub input3_loc: MemArea,
     pub input4: types::Excuse,
-    pub input4_loc: u32,
-    pub input4_ptr_loc: u32,
+    pub input4_loc: MemArea,
+    pub input4_ptr_loc: MemArea,
 }
 
 impl BazExercise {
@@ -208,12 +259,12 @@ impl BazExercise {
         (
             excuse_strat(),
             excuse_strat(),
-            HostMemory::pointer_strat(4),
+            HostMemory::mem_area_strat(4),
             excuse_strat(),
-            HostMemory::pointer_strat(4),
+            HostMemory::mem_area_strat(4),
             excuse_strat(),
-            HostMemory::pointer_strat(4),
-            HostMemory::pointer_strat(4),
+            HostMemory::mem_area_strat(4),
+            HostMemory::mem_area_strat(4),
         )
             .prop_map(
                 |(
@@ -237,12 +288,12 @@ impl BazExercise {
                 },
             )
             .prop_filter("non-overlapping pointers", |e| {
-                e.input2_loc != e.input3_loc
-                    && e.input2_loc != e.input4_loc
-                    && e.input2_loc != e.input4_ptr_loc
-                    && e.input3_loc != e.input4_loc
-                    && e.input3_loc != e.input4_ptr_loc
-                    && e.input4_loc != e.input4_ptr_loc
+                non_overlapping_set(&[
+                    &e.input2_loc,
+                    &e.input3_loc,
+                    &e.input4_loc,
+                    &e.input4_ptr_loc,
+                ])
             })
             .boxed()
     }
@@ -253,145 +304,191 @@ impl BazExercise {
             memory::GuestMemory::new(host_memory.as_mut_ptr(), host_memory.len() as u32);
 
         *guest_memory
-            .ptr_mut(self.input2_loc)
+            .ptr_mut(self.input2_loc.ptr)
             .expect("input2 ptr")
             .as_ref_mut()
             .expect("input2 ref_mut") = self.input2;
 
         *guest_memory
-            .ptr_mut(self.input3_loc)
+            .ptr_mut(self.input3_loc.ptr)
             .expect("input3 ptr")
             .as_ref_mut()
             .expect("input3 ref_mut") = self.input3;
 
         *guest_memory
-            .ptr_mut(self.input4_loc)
+            .ptr_mut(self.input4_loc.ptr)
             .expect("input4 ptr")
             .as_ref_mut()
             .expect("input4 ref_mut") = self.input4;
 
         *guest_memory
-            .ptr_mut(self.input4_ptr_loc)
+            .ptr_mut(self.input4_ptr_loc.ptr)
             .expect("input4 ptr ptr")
             .as_ref_mut()
-            .expect("input4 ptr ref_mut") = self.input4_loc;
+            .expect("input4 ptr ref_mut") = self.input4_loc.ptr;
 
         let baz_err = foo::baz(
             &mut ctx,
             &mut guest_memory,
             self.input1.into(),
-            self.input2_loc as i32,
-            self.input3_loc as i32,
-            self.input4_ptr_loc as i32,
+            self.input2_loc.ptr as i32,
+            self.input3_loc.ptr as i32,
+            self.input4_ptr_loc.ptr as i32,
         );
-        assert_eq!(baz_err, types::Errno::Ok.into());
+        assert_eq!(baz_err, types::Errno::Ok.into(), "baz errno");
 
         // Implementation of baz writes input3 to the input2_loc:
         let written_to_input2_loc: i32 = *guest_memory
-            .ptr(self.input2_loc)
+            .ptr(self.input2_loc.ptr)
             .expect("input2 ptr")
             .as_ref()
             .expect("input2 ref");
 
-        assert_eq!(written_to_input2_loc, self.input3.into());
+        assert_eq!(
+            written_to_input2_loc,
+            self.input3.into(),
+            "baz written to input2"
+        );
 
         // Implementation of baz writes input2_loc to input4_ptr_loc:
         let written_to_input4_ptr: u32 = *guest_memory
-            .ptr(self.input4_ptr_loc)
+            .ptr(self.input4_ptr_loc.ptr)
             .expect("input4_ptr_loc ptr")
             .as_ref()
             .expect("input4_ptr_loc ref");
 
-        assert_eq!(written_to_input4_ptr, self.input2_loc);
+        assert_eq!(
+            written_to_input4_ptr, self.input2_loc.ptr,
+            "baz written to input4_ptr"
+        );
     }
 }
 proptest! {
     #[test]
     fn baz(e in BazExercise::strat()) {
         e.test();
-        BazExercise {
-            input1: types::Excuse::DogAte,
-            input2: types::Excuse::Traffic,
-            input2_loc: 0,
-            input3: types::Excuse::Sleeping,
-            input3_loc: 4,
-            input4: types::Excuse::DogAte,
-            input4_loc: 8,
-            input4_ptr_loc: 12,
-        }
-        .test()
     }
 }
 
 #[derive(Debug)]
 struct SumOfPairExercise {
     pub input: types::PairInts,
-    pub input_loc: u32,
-    pub return_loc: u32,
+    pub input_loc: MemArea,
+    pub return_loc: MemArea,
 }
 
 impl SumOfPairExercise {
+    pub fn strat() -> BoxedStrategy<Self> {
+        (
+            prop::num::i32::ANY,
+            prop::num::i32::ANY,
+            HostMemory::mem_area_strat(8),
+            HostMemory::mem_area_strat(8),
+        )
+            .prop_map(|(first, second, input_loc, return_loc)| SumOfPairExercise {
+                input: types::PairInts { first, second },
+                input_loc,
+                return_loc,
+            })
+            .prop_filter("non-overlapping pointers", |e| {
+                non_overlapping_set(&[&e.input_loc, &e.return_loc])
+            })
+            .boxed()
+    }
+
     pub fn test(&self) {
         let mut ctx = WasiCtx::new();
         let mut host_memory = HostMemory::new();
         let mut guest_memory =
             memory::GuestMemory::new(host_memory.as_mut_ptr(), host_memory.len() as u32);
+
         *guest_memory
-            .ptr_mut(self.input_loc)
+            .ptr_mut(self.input_loc.ptr)
             .expect("input ptr")
             .as_ref_mut()
             .expect("input ref_mut") = self.input.first;
         *guest_memory
-            .ptr_mut(self.input_loc + 4)
+            .ptr_mut(self.input_loc.ptr + 4)
             .expect("input ptr")
             .as_ref_mut()
             .expect("input ref_mut") = self.input.second;
         let sum_err = foo::sum_of_pair(
             &mut ctx,
             &mut guest_memory,
-            self.input_loc as i32,
-            self.return_loc as i32,
+            self.input_loc.ptr as i32,
+            self.return_loc.ptr as i32,
         );
 
-        assert_eq!(sum_err, types::Errno::Ok.into());
+        assert_eq!(sum_err, types::Errno::Ok.into(), "sum errno");
 
         let return_val: i64 = *guest_memory
-            .ptr(self.return_loc)
+            .ptr(self.return_loc.ptr)
             .expect("return ptr")
             .as_ref()
             .expect("return ref");
 
         assert_eq!(
             return_val,
-            self.input.first as i64 + self.input.second as i64
+            self.input.first as i64 + self.input.second as i64,
+            "sum return value"
         );
     }
 }
 
-#[test]
-fn sum_of_pair() {
-    SumOfPairExercise {
-        input: types::PairInts {
-            first: 1,
-            second: 2,
-        },
-        input_loc: 0,
-        return_loc: 8,
+proptest! {
+    #[test]
+    fn sum_of_pair(e in SumOfPairExercise::strat()) {
+        e.test();
     }
-    .test()
 }
 
 #[derive(Debug)]
 struct SumPairPtrsExercise {
     input_first: i32,
     input_second: i32,
-    input_first_loc: u32,
-    input_second_loc: u32,
-    input_struct_loc: u32,
-    return_loc: u32,
+    input_first_loc: MemArea,
+    input_second_loc: MemArea,
+    input_struct_loc: MemArea,
+    return_loc: MemArea,
 }
 
 impl SumPairPtrsExercise {
+    pub fn strat() -> BoxedStrategy<Self> {
+        (
+            prop::num::i32::ANY,
+            prop::num::i32::ANY,
+            HostMemory::mem_area_strat(4),
+            HostMemory::mem_area_strat(4),
+            HostMemory::mem_area_strat(8),
+            HostMemory::mem_area_strat(8),
+        )
+            .prop_map(
+                |(
+                    input_first,
+                    input_second,
+                    input_first_loc,
+                    input_second_loc,
+                    input_struct_loc,
+                    return_loc,
+                )| SumPairPtrsExercise {
+                    input_first,
+                    input_second,
+                    input_first_loc,
+                    input_second_loc,
+                    input_struct_loc,
+                    return_loc,
+                },
+            )
+            .prop_filter("non-overlapping pointers", |e| {
+                non_overlapping_set(&[
+                    &e.input_first_loc,
+                    &e.input_second_loc,
+                    &e.input_struct_loc,
+                    &e.return_loc,
+                ])
+            })
+            .boxed()
+    }
     pub fn test(&self) {
         let mut ctx = WasiCtx::new();
         let mut host_memory = HostMemory::new();
@@ -399,58 +496,52 @@ impl SumPairPtrsExercise {
             memory::GuestMemory::new(host_memory.as_mut_ptr(), host_memory.len() as u32);
 
         *guest_memory
-            .ptr_mut(self.input_first_loc)
+            .ptr_mut(self.input_first_loc.ptr)
             .expect("input_first ptr")
             .as_ref_mut()
             .expect("input_first ref") = self.input_first;
         *guest_memory
-            .ptr_mut(self.input_second_loc)
+            .ptr_mut(self.input_second_loc.ptr)
             .expect("input_second ptr")
             .as_ref_mut()
             .expect("input_second ref") = self.input_second;
 
         *guest_memory
-            .ptr_mut(self.input_struct_loc)
+            .ptr_mut(self.input_struct_loc.ptr)
             .expect("input_struct ptr")
             .as_ref_mut()
-            .expect("input_struct ref") = self.input_first_loc;
+            .expect("input_struct ref") = self.input_first_loc.ptr;
         *guest_memory
-            .ptr_mut(self.input_struct_loc + 4)
+            .ptr_mut(self.input_struct_loc.ptr + 4)
             .expect("input_struct ptr")
             .as_ref_mut()
-            .expect("input_struct ref") = self.input_second_loc;
+            .expect("input_struct ref") = self.input_second_loc.ptr;
 
         let res = foo::sum_of_pair_of_ptrs(
             &mut ctx,
             &mut guest_memory,
-            self.input_struct_loc as i32,
-            self.return_loc as i32,
+            self.input_struct_loc.ptr as i32,
+            self.return_loc.ptr as i32,
         );
 
-        assert_eq!(res, types::Errno::Ok.into());
+        assert_eq!(res, types::Errno::Ok.into(), "sum of pair of ptrs errno");
 
         let doubled: i64 = *guest_memory
-            .ptr(self.return_loc)
+            .ptr(self.return_loc.ptr)
             .expect("return ptr")
             .as_ref()
             .expect("return ref");
 
         assert_eq!(
             doubled,
-            (self.input_first as i64) + (self.input_second as i64)
+            (self.input_first as i64) + (self.input_second as i64),
+            "sum of pair of ptrs return val"
         );
     }
 }
-
-#[test]
-fn sum_of_pair_of_ptrs() {
-    SumPairPtrsExercise {
-        input_first: 1,
-        input_second: 2,
-        input_first_loc: 0,
-        input_second_loc: 4,
-        input_struct_loc: 8,
-        return_loc: 16,
+proptest! {
+    #[test]
+    fn sum_of_pair_of_ptrs(e in SumPairPtrsExercise::strat()) {
+        e.test()
     }
-    .test()
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -25,48 +25,48 @@ impl foo::Foo for WasiCtx {
 
     fn baz(
         &mut self,
-        excuse: types::Excuse,
-        a_better_excuse_by_reference: ::memory::GuestPtrMut<types::Excuse>,
-        a_lamer_excuse_by_reference: ::memory::GuestPtr<types::Excuse>,
-        two_layers_of_excuses: ::memory::GuestPtrMut<::memory::GuestPtr<types::Excuse>>,
+        input1: types::Excuse,
+        input2_ptr: ::memory::GuestPtrMut<types::Excuse>,
+        input3_ptr: ::memory::GuestPtr<types::Excuse>,
+        input4_ptr_ptr: ::memory::GuestPtrMut<::memory::GuestPtr<types::Excuse>>,
     ) -> Result<(), types::Errno> {
-        println!("BAZ excuse {:?}", excuse);
+        println!("BAZ input1 {:?}", input1);
         // Read enum value from mutable:
-        let mut a_better_excuse_ref: ::memory::GuestRefMut<types::Excuse> =
-            a_better_excuse_by_reference.as_ref_mut().map_err(|e| {
-                eprintln!("a_better_excuse_by_reference error: {}", e);
+        let mut input2_ref: ::memory::GuestRefMut<types::Excuse> =
+            input2_ptr.as_ref_mut().map_err(|e| {
+                eprintln!("input2_ptr error: {}", e);
                 types::Errno::InvalidArg
             })?;
-        let a_better_excuse: types::Excuse = *a_better_excuse_ref;
-        println!("a_better_excuse {:?}", a_better_excuse);
+        let input2: types::Excuse = *input2_ref;
+        println!("input2 {:?}", input2);
 
         // Read enum value from immutable ptr:
-        let a_lamer_excuse = *a_lamer_excuse_by_reference.as_ref().map_err(|e| {
-            eprintln!("a_lamer_excuse_by_reference error: {}", e);
+        let input3 = *input3_ptr.as_ref().map_err(|e| {
+            eprintln!("input3_ptr error: {}", e);
             types::Errno::InvalidArg
         })?;
-        println!("a_lamer_excuse {:?}", a_lamer_excuse);
+        println!("input3 {:?}", input3);
 
         // Write enum to mutable ptr:
-        *a_better_excuse_ref = a_lamer_excuse;
-        println!("wrote to a_better_excuse_ref {:?}", *a_better_excuse_ref);
+        *input2_ref = input3;
+        println!("wrote to input2_ref {:?}", input3);
 
         // Read ptr value from mutable ptr:
-        let one_layer_down: ::memory::GuestPtr<types::Excuse> =
-            two_layers_of_excuses.read_ptr_from_guest().map_err(|e| {
-                eprintln!("one_layer_down error: {}", e);
+        let input4_ptr: ::memory::GuestPtr<types::Excuse> =
+            input4_ptr_ptr.read_ptr_from_guest().map_err(|e| {
+                eprintln!("input4_ptr_ptr error: {}", e);
                 types::Errno::InvalidArg
             })?;
 
         // Read enum value from that ptr:
-        let two_layers_down: types::Excuse = *one_layer_down.as_ref().map_err(|e| {
-            eprintln!("two_layers_down error: {}", e);
+        let input4: types::Excuse = *input4_ptr.as_ref().map_err(|e| {
+            eprintln!("input4_ptr error: {}", e);
             types::Errno::InvalidArg
         })?;
-        println!("two layers down {:?}", two_layers_down);
+        println!("input4 {:?}", input4);
 
         // Write ptr value to mutable ptr:
-        two_layers_of_excuses.write_ptr_to_guest(&a_better_excuse_by_reference.as_immut());
+        input4_ptr_ptr.write_ptr_to_guest(&input2_ptr.as_immut());
 
         Ok(())
     }


### PR DESCRIPTION
First refactors the test suite to test the lower-level function that takes ABI types, in addition to the user trait method.

Then, refactors those tests to use proptest to search a wide variety of inputs. For now, we only search for inputs that are valid (neither the lower function nor the user trait should throw an error).
