### PR TITLE
Add basic GuestString support to wiggle

### DIFF
--- a/crates/generate/src/funcs.rs
+++ b/crates/generate/src/funcs.rs
@@ -181,7 +181,23 @@ fn marshal_arg(
                     let #name = #name as #interface_typename;
                 }
             }
-            witx::BuiltinType::String => unimplemented!("string types unimplemented"),
+            witx::BuiltinType::String => {
+                let arg_name = names.func_ptr_binding(&param.name);
+                let name = names.func_param(&param.name);
+                quote! {
+                    let #name = match memory.ptr::<u8>(#arg_name as u32) {
+                        Ok(p) => match p.string() {
+                            Ok(s) => s,
+                            Err(e) => {
+                                #error_handling
+                            }
+                        }
+                        Err(e) => {
+                            #error_handling
+                        }
+                    };
+                }
+            }
         },
         witx::Type::Pointer(pointee) => {
             let pointee_type = names.type_ref(pointee, anon_lifetime());

--- a/crates/generate/src/names.rs
+++ b/crates/generate/src/names.rs
@@ -24,7 +24,7 @@ impl Names {
     }
     pub fn builtin_type(&self, b: BuiltinType) -> TokenStream {
         match b {
-            BuiltinType::String => quote!(String),
+            BuiltinType::String => quote!(wiggle_runtime::GuestString),
             BuiltinType::U8 => quote!(u8),
             BuiltinType::U16 => quote!(u16),
             BuiltinType::U32 => quote!(u32),
@@ -35,7 +35,7 @@ impl Names {
             BuiltinType::S64 => quote!(i64),
             BuiltinType::F32 => quote!(f32),
             BuiltinType::F64 => quote!(f64),
-            BuiltinType::Char8 => quote!(char),
+            BuiltinType::Char8 => quote!(u8),
             BuiltinType::USize => quote!(usize),
         }
     }

--- a/crates/generate/src/names.rs
+++ b/crates/generate/src/names.rs
@@ -22,9 +22,9 @@ impl Names {
         let ident = format_ident!("{}", id.as_str().to_camel_case());
         quote!(#ident)
     }
-    pub fn builtin_type(&self, b: BuiltinType) -> TokenStream {
+    pub fn builtin_type(&self, b: BuiltinType, lifetime: TokenStream) -> TokenStream {
         match b {
-            BuiltinType::String => quote!(wiggle_runtime::GuestString),
+            BuiltinType::String => quote!(wiggle_runtime::GuestString<#lifetime>),
             BuiltinType::U8 => quote!(u8),
             BuiltinType::U16 => quote!(u16),
             BuiltinType::U32 => quote!(u32),
@@ -59,7 +59,7 @@ impl Names {
                 }
             }
             TypeRef::Value(ty) => match &**ty {
-                witx::Type::Builtin(builtin) => self.builtin_type(*builtin),
+                witx::Type::Builtin(builtin) => self.builtin_type(*builtin, lifetime.clone()),
                 witx::Type::Pointer(pointee) => {
                     let pointee_type = self.type_ref(&pointee, lifetime.clone());
                     quote!(wiggle_runtime::GuestPtrMut<#lifetime, #pointee_type>)

--- a/crates/generate/src/types.rs
+++ b/crates/generate/src/types.rs
@@ -286,13 +286,17 @@ fn define_enum(names: &Names, name: &witx::Id, e: &witx::EnumDatatype) -> TokenS
 fn define_builtin(names: &Names, name: &witx::Id, builtin: witx::BuiltinType) -> TokenStream {
     let ident = names.type_(name);
     let built = names.builtin_type(builtin);
-    quote!(pub type #ident = #built;)
+    if let witx::BuiltinType::String = builtin {
+        quote!(pub type #ident<'a> = #built<'a>;)
+    } else {
+        quote!(pub type #ident = #built;)
+    }
 }
 
 pub fn type_needs_lifetime(tref: &witx::TypeRef) -> bool {
     match &*tref.type_() {
         witx::Type::Builtin(b) => match b {
-            witx::BuiltinType::String => unimplemented!(),
+            witx::BuiltinType::String => true,
             _ => false,
         },
         witx::Type::Enum { .. }

--- a/crates/generate/src/types.rs
+++ b/crates/generate/src/types.rs
@@ -285,9 +285,9 @@ fn define_enum(names: &Names, name: &witx::Id, e: &witx::EnumDatatype) -> TokenS
 
 fn define_builtin(names: &Names, name: &witx::Id, builtin: witx::BuiltinType) -> TokenStream {
     let ident = names.type_(name);
-    let built = names.builtin_type(builtin);
+    let built = names.builtin_type(builtin, quote!('a));
     if let witx::BuiltinType::String = builtin {
-        quote!(pub type #ident<'a> = #built<'a>;)
+        quote!(pub type #ident<'a> = #built;)
     } else {
         quote!(pub type #ident = #built;)
     }
@@ -396,7 +396,7 @@ fn define_ptr_struct(names: &Names, name: &witx::Id, s: &witx::StructDatatype) -
         let type_ = match &m.tref {
             witx::TypeRef::Name(nt) => names.type_(&nt.name),
             witx::TypeRef::Value(ty) => match &**ty {
-                witx::Type::Builtin(builtin) => names.builtin_type(*builtin),
+                witx::Type::Builtin(builtin) => names.builtin_type(*builtin, quote!('a)),
                 witx::Type::Pointer(pointee) => {
                     let pointee_type = names.type_ref(&pointee, quote!('a));
                     quote!(wiggle_runtime::GuestPtrMut<'a, #pointee_type>)
@@ -414,7 +414,7 @@ fn define_ptr_struct(names: &Names, name: &witx::Id, s: &witx::StructDatatype) -
         let type_ = match &ml.member.tref {
             witx::TypeRef::Name(nt) => names.type_(&nt.name),
             witx::TypeRef::Value(ty) => match &**ty {
-                witx::Type::Builtin(builtin) => names.builtin_type(*builtin),
+                witx::Type::Builtin(builtin) => names.builtin_type(*builtin, quote!('a)),
                 witx::Type::Pointer(pointee) => {
                     let pointee_type = names.type_ref(&pointee, anon_lifetime());
                     quote!(wiggle_runtime::GuestPtrMut::<#pointee_type>)
@@ -457,7 +457,7 @@ fn define_ptr_struct(names: &Names, name: &witx::Id, s: &witx::StructDatatype) -
             }
             witx::TypeRef::Value(ty) => match &**ty {
                 witx::Type::Builtin(builtin) => {
-                    let type_ = names.builtin_type(*builtin);
+                    let type_ = names.builtin_type(*builtin, anon_lifetime());
                     quote! {
                         let #name = #type_::read_from_guest(&location.cast(#offset)?)?;
                     }

--- a/crates/runtime/src/error.rs
+++ b/crates/runtime/src/error.rs
@@ -27,4 +27,7 @@ pub enum GuestError {
         #[source]
         err: Box<GuestError>,
     },
+    // FIXME the error should be more verbose and should print all valid_up_to chars
+    #[error("Invalid UTF-8 encountered")]
+    InvalidUtf8,
 }

--- a/crates/runtime/src/error.rs
+++ b/crates/runtime/src/error.rs
@@ -27,7 +27,6 @@ pub enum GuestError {
         #[source]
         err: Box<GuestError>,
     },
-    // FIXME the error should be more verbose and should print all valid_up_to chars
     #[error("Invalid UTF-8 encountered")]
-    InvalidUtf8,
+    InvalidUtf8(#[from] std::str::Utf8Error),
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -6,5 +6,8 @@ mod region;
 
 pub use error::GuestError;
 pub use guest_type::{GuestErrorType, GuestType, GuestTypeClone, GuestTypeCopy};
-pub use memory::{GuestArray, GuestMemory, GuestPtr, GuestPtrMut, GuestRef, GuestRefMut};
+pub use memory::{
+    GuestArray, GuestMemory, GuestPtr, GuestPtrMut, GuestRef, GuestRefMut, GuestString,
+    GuestStringRef,
+};
 pub use region::Region;

--- a/crates/runtime/src/memory/mod.rs
+++ b/crates/runtime/src/memory/mod.rs
@@ -1,8 +1,10 @@
 mod array;
 mod ptr;
+mod string;
 
 pub use array::*;
 pub use ptr::*;
+pub use string::*;
 
 use crate::{borrow::GuestBorrows, GuestError, GuestType, Region};
 use std::{cell::RefCell, fmt, marker::PhantomData, rc::Rc};

--- a/crates/runtime/src/memory/ptr.rs
+++ b/crates/runtime/src/memory/ptr.rs
@@ -1,5 +1,8 @@
-use super::{array::GuestArray, string::GuestString, GuestMemory};
-use crate::{borrow::BorrowHandle, GuestError, GuestType, GuestTypeClone, GuestTypeCopy, Region};
+use super::{array::GuestArray, GuestMemory};
+use crate::{
+    borrow::BorrowHandle, GuestError, GuestType, GuestTypeClone, GuestTypeCopy,
+    Region,
+};
 use std::{
     fmt,
     marker::PhantomData,
@@ -52,19 +55,6 @@ impl<'a, T: GuestType> GuestPtr<'a, T> {
         } else {
             Err(GuestError::PtrOutOfBounds(region))
         }
-    }
-}
-
-impl<'a> GuestPtr<'a, u8> {
-    pub fn string(&self) -> Result<GuestString<'a>, GuestError> {
-        // WASI strings are null-terminated UTF-8 strings, so search for null
-        let len = unsafe {
-            std::ffi::CStr::from_ptr(self.as_raw() as *const _)
-                .to_bytes_with_nul() // we take into account the null-byte so that later
-                .len() // we can properly mark entire memory chunk as borrowed
-        };
-        let array = self.array(len as u32)?;
-        Ok(GuestString { array })
     }
 }
 

--- a/crates/runtime/src/memory/ptr.rs
+++ b/crates/runtime/src/memory/ptr.rs
@@ -1,8 +1,5 @@
 use super::{array::GuestArray, GuestMemory};
-use crate::{
-    borrow::BorrowHandle, GuestError, GuestType, GuestTypeClone, GuestTypeCopy,
-    Region,
-};
+use crate::{borrow::BorrowHandle, GuestError, GuestType, GuestTypeClone, GuestTypeCopy, Region};
 use std::{
     fmt,
     marker::PhantomData,

--- a/crates/runtime/src/memory/ptr.rs
+++ b/crates/runtime/src/memory/ptr.rs
@@ -60,8 +60,8 @@ impl<'a> GuestPtr<'a, u8> {
         // WASI strings are null-terminated UTF-8 strings, so search for null
         let len = unsafe {
             std::ffi::CStr::from_ptr(self.as_raw() as *const _)
-                .to_bytes()
-                .len()
+                .to_bytes_with_nul() // we take into account the null-byte so that later
+                .len() // we can properly mark entire memory chunk as borrowed
         };
         let array = self.array(len as u32)?;
         Ok(GuestString { array })

--- a/crates/runtime/src/memory/string.rs
+++ b/crates/runtime/src/memory/string.rs
@@ -1,0 +1,157 @@
+use super::array::{GuestArray, GuestArrayRef};
+use crate::GuestError;
+use std::{fmt, ops::Deref};
+
+pub struct GuestString<'a> {
+    pub(super) array: GuestArray<'a, u8>,
+}
+
+impl<'a> fmt::Debug for GuestString<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "GuestString {{ array: {:?} }}", self.array)
+    }
+}
+
+impl<'a> GuestString<'a> {
+    pub fn as_ref(&self) -> Result<GuestStringRef<'a>, GuestError> {
+        let ref_ = self.array.as_ref()?;
+        Ok(GuestStringRef { ref_ })
+    }
+
+    pub fn to_string(&self) -> Result<String, GuestError> {
+        Ok(self.as_ref()?.as_str()?.to_owned())
+    }
+}
+
+pub struct GuestStringRef<'a> {
+    pub(super) ref_: GuestArrayRef<'a, u8>,
+}
+
+impl<'a> fmt::Debug for GuestStringRef<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "GuestStringRef {{ ref_: {:?} }}", self.ref_)
+    }
+}
+
+impl<'a> GuestStringRef<'a> {
+    pub fn as_str(&self) -> Result<&str, GuestError> {
+        std::str::from_utf8(self.ref_.deref()).map_err(|_| GuestError::InvalidUtf8)
+    }
+}
+
+// #[cfg(test)]
+// mod test {
+//     use super::super::{
+//         ptr::{GuestPtr, GuestPtrMut},
+//         GuestError, GuestMemory, Region,
+//     };
+
+//     #[repr(align(4096))]
+//     struct HostMemory {
+//         buffer: [u8; 4096],
+//     }
+
+//     impl HostMemory {
+//         pub fn new() -> Self {
+//             Self { buffer: [0; 4096] }
+//         }
+//         pub fn as_mut_ptr(&mut self) -> *mut u8 {
+//             self.buffer.as_mut_ptr()
+//         }
+//         pub fn len(&self) -> usize {
+//             self.buffer.len()
+//         }
+//     }
+
+//     #[test]
+//     fn out_of_bounds() {
+//         let mut host_memory = HostMemory::new();
+//         let guest_memory = GuestMemory::new(host_memory.as_mut_ptr(), host_memory.len() as u32);
+//         // try extracting an array out of memory bounds
+//         let ptr: GuestPtr<i32> = guest_memory.ptr(4092).expect("ptr to last i32 el");
+//         let err = ptr.array(2).expect_err("out of bounds ptr error");
+//         assert_eq!(err, GuestError::PtrOutOfBounds(Region::new(4092, 8)));
+//     }
+
+//     #[test]
+//     fn ptr_to_array() {
+//         let mut host_memory = HostMemory::new();
+//         let guest_memory = GuestMemory::new(host_memory.as_mut_ptr(), host_memory.len() as u32);
+//         // write a simple array into memory
+//         {
+//             let ptr: GuestPtrMut<i32> = guest_memory.ptr_mut(0).expect("ptr mut to first el");
+//             let mut el = ptr.as_ref_mut().expect("ref mut to first el");
+//             *el = 1;
+//             let ptr: GuestPtrMut<i32> = guest_memory.ptr_mut(4).expect("ptr mut to second el");
+//             let mut el = ptr.as_ref_mut().expect("ref mu to second el");
+//             *el = 2;
+//             let ptr: GuestPtrMut<i32> = guest_memory.ptr_mut(8).expect("ptr mut to third el");
+//             let mut el = ptr.as_ref_mut().expect("ref mut to third el");
+//             *el = 3;
+//         }
+//         // extract as array
+//         let ptr: GuestPtr<i32> = guest_memory.ptr(0).expect("ptr to first el");
+//         let arr = ptr.array(3).expect("convert ptr to array");
+//         let as_ref = &*arr.as_ref().expect("array borrowed immutably");
+//         assert_eq!(as_ref, &[1, 2, 3]);
+//         // borrowing again should be fine
+//         let as_ref2 = &*arr.as_ref().expect("array borrowed immutably again");
+//         assert_eq!(as_ref2, as_ref);
+//     }
+
+//     #[test]
+//     fn ptr_to_ptr_array() {
+//         let mut host_memory = HostMemory::new();
+//         let guest_memory = GuestMemory::new(host_memory.as_mut_ptr(), host_memory.len() as u32);
+//         {
+//             let val_ptr: GuestPtrMut<u8> =
+//                 guest_memory.ptr_mut(0).expect("ptr mut to the first value");
+//             let mut val = val_ptr.as_ref_mut().expect("ref mut to the first value");
+//             *val = 255;
+//             let val_ptr: GuestPtrMut<u8> = guest_memory
+//                 .ptr_mut(4)
+//                 .expect("ptr mut to the second value");
+//             let mut val = val_ptr.as_ref_mut().expect("ref mut to the second value");
+//             *val = 254;
+//             let val_ptr: GuestPtrMut<u8> =
+//                 guest_memory.ptr_mut(8).expect("ptr mut to the third value");
+//             let mut val = val_ptr.as_ref_mut().expect("ref mut to the third value");
+//             *val = 253;
+//         }
+//         {
+//             let ptr = guest_memory.ptr_mut(12).expect("ptr mut to first el");
+//             ptr.write_ptr_to_guest(
+//                 &guest_memory
+//                     .ptr::<GuestPtr<u8>>(0)
+//                     .expect("ptr to the first value"),
+//             );
+//             let ptr = guest_memory.ptr_mut(16).expect("ptr mut to first el");
+//             ptr.write_ptr_to_guest(
+//                 &guest_memory
+//                     .ptr::<GuestPtr<u8>>(4)
+//                     .expect("ptr to the second value"),
+//             );
+//             let ptr = guest_memory.ptr_mut(20).expect("ptr mut to first el");
+//             ptr.write_ptr_to_guest(
+//                 &guest_memory
+//                     .ptr::<GuestPtr<u8>>(8)
+//                     .expect("ptr to the third value"),
+//             );
+//         }
+//         // extract as array
+//         let ptr: GuestPtr<GuestPtr<u8>> = guest_memory.ptr(12).expect("ptr to first el");
+//         let arr = ptr.array(3).expect("convert ptr to array");
+//         let contents = arr
+//             .iter()
+//             .map(|ptr_ptr| {
+//                 *ptr_ptr
+//                     .expect("valid ptr to ptr")
+//                     .read_ptr_from_guest()
+//                     .expect("valid ptr to some value")
+//                     .as_ref()
+//                     .expect("deref ptr to some value")
+//             })
+//             .collect::<Vec<_>>();
+//         assert_eq!(&contents, &[255, 254, 253]);
+//     }
+// }

--- a/crates/runtime/src/memory/string.rs
+++ b/crates/runtime/src/memory/string.rs
@@ -78,7 +78,6 @@ mod test {
         let guest_memory = GuestMemory::new(host_memory.as_mut_ptr(), host_memory.len() as u32);
         // write string into memory
         let mut ptr: GuestPtrMut<u8> = guest_memory.ptr_mut(0).expect("ptr mut to start of string");
-        // let input_str = "cześć WASI!";
         let input_str = "cześć WASI!";
         for byte in input_str.as_bytes() {
             let mut ref_mut = ptr.as_ref_mut().expect("valid deref");

--- a/crates/runtime/src/memory/string.rs
+++ b/crates/runtime/src/memory/string.rs
@@ -35,123 +35,79 @@ impl<'a> fmt::Debug for GuestStringRef<'a> {
 
 impl<'a> GuestStringRef<'a> {
     pub fn as_str(&self) -> Result<&str, GuestError> {
-        std::str::from_utf8(self.ref_.deref()).map_err(|_| GuestError::InvalidUtf8)
+        let bytes = self.ref_.deref();
+        let len = bytes.len();
+        std::str::from_utf8(&bytes[..len - 1]).map_err(|_| GuestError::InvalidUtf8)
     }
 }
 
-// #[cfg(test)]
-// mod test {
-//     use super::super::{
-//         ptr::{GuestPtr, GuestPtrMut},
-//         GuestError, GuestMemory, Region,
-//     };
+#[cfg(test)]
+mod test {
+    use super::super::{
+        ptr::{GuestPtr, GuestPtrMut},
+        GuestError, GuestMemory,
+    };
 
-//     #[repr(align(4096))]
-//     struct HostMemory {
-//         buffer: [u8; 4096],
-//     }
+    #[repr(align(4096))]
+    struct HostMemory {
+        buffer: [u8; 4096],
+    }
 
-//     impl HostMemory {
-//         pub fn new() -> Self {
-//             Self { buffer: [0; 4096] }
-//         }
-//         pub fn as_mut_ptr(&mut self) -> *mut u8 {
-//             self.buffer.as_mut_ptr()
-//         }
-//         pub fn len(&self) -> usize {
-//             self.buffer.len()
-//         }
-//     }
+    impl HostMemory {
+        pub fn new() -> Self {
+            Self { buffer: [0; 4096] }
+        }
+        pub fn as_mut_ptr(&mut self) -> *mut u8 {
+            self.buffer.as_mut_ptr()
+        }
+        pub fn len(&self) -> usize {
+            self.buffer.len()
+        }
+    }
 
-//     #[test]
-//     fn out_of_bounds() {
-//         let mut host_memory = HostMemory::new();
-//         let guest_memory = GuestMemory::new(host_memory.as_mut_ptr(), host_memory.len() as u32);
-//         // try extracting an array out of memory bounds
-//         let ptr: GuestPtr<i32> = guest_memory.ptr(4092).expect("ptr to last i32 el");
-//         let err = ptr.array(2).expect_err("out of bounds ptr error");
-//         assert_eq!(err, GuestError::PtrOutOfBounds(Region::new(4092, 8)));
-//     }
+    #[test]
+    fn valid_utf8() {
+        let mut host_memory = HostMemory::new();
+        // poison all host's memory so that we test for null-termination
+        host_memory.buffer = [1; 4096];
+        let guest_memory = GuestMemory::new(host_memory.as_mut_ptr(), host_memory.len() as u32);
+        // write string into memory
+        let mut ptr: GuestPtrMut<u8> = guest_memory.ptr_mut(0).expect("ptr mut to start of string");
+        let input_str = "cześć WASI!";
+        let mut bytes = input_str.as_bytes().to_vec();
+        bytes.push(b'\0');
+        for byte in bytes {
+            let mut ref_mut = ptr.as_ref_mut().expect("valid deref");
+            *ref_mut = byte;
+            ptr = ptr.elem(1).expect("next ptr");
+        }
+        // read the string as GuestString
+        let ptr: GuestPtr<u8> = guest_memory.ptr(0).expect("ptr to start of string");
+        let guest_string = ptr.string().expect("valid null-terminated string");
+        let as_ref = guest_string.as_ref().expect("deref");
+        assert_eq!(as_ref.as_str().expect("valid UTF-8"), input_str);
+    }
 
-//     #[test]
-//     fn ptr_to_array() {
-//         let mut host_memory = HostMemory::new();
-//         let guest_memory = GuestMemory::new(host_memory.as_mut_ptr(), host_memory.len() as u32);
-//         // write a simple array into memory
-//         {
-//             let ptr: GuestPtrMut<i32> = guest_memory.ptr_mut(0).expect("ptr mut to first el");
-//             let mut el = ptr.as_ref_mut().expect("ref mut to first el");
-//             *el = 1;
-//             let ptr: GuestPtrMut<i32> = guest_memory.ptr_mut(4).expect("ptr mut to second el");
-//             let mut el = ptr.as_ref_mut().expect("ref mu to second el");
-//             *el = 2;
-//             let ptr: GuestPtrMut<i32> = guest_memory.ptr_mut(8).expect("ptr mut to third el");
-//             let mut el = ptr.as_ref_mut().expect("ref mut to third el");
-//             *el = 3;
-//         }
-//         // extract as array
-//         let ptr: GuestPtr<i32> = guest_memory.ptr(0).expect("ptr to first el");
-//         let arr = ptr.array(3).expect("convert ptr to array");
-//         let as_ref = &*arr.as_ref().expect("array borrowed immutably");
-//         assert_eq!(as_ref, &[1, 2, 3]);
-//         // borrowing again should be fine
-//         let as_ref2 = &*arr.as_ref().expect("array borrowed immutably again");
-//         assert_eq!(as_ref2, as_ref);
-//     }
-
-//     #[test]
-//     fn ptr_to_ptr_array() {
-//         let mut host_memory = HostMemory::new();
-//         let guest_memory = GuestMemory::new(host_memory.as_mut_ptr(), host_memory.len() as u32);
-//         {
-//             let val_ptr: GuestPtrMut<u8> =
-//                 guest_memory.ptr_mut(0).expect("ptr mut to the first value");
-//             let mut val = val_ptr.as_ref_mut().expect("ref mut to the first value");
-//             *val = 255;
-//             let val_ptr: GuestPtrMut<u8> = guest_memory
-//                 .ptr_mut(4)
-//                 .expect("ptr mut to the second value");
-//             let mut val = val_ptr.as_ref_mut().expect("ref mut to the second value");
-//             *val = 254;
-//             let val_ptr: GuestPtrMut<u8> =
-//                 guest_memory.ptr_mut(8).expect("ptr mut to the third value");
-//             let mut val = val_ptr.as_ref_mut().expect("ref mut to the third value");
-//             *val = 253;
-//         }
-//         {
-//             let ptr = guest_memory.ptr_mut(12).expect("ptr mut to first el");
-//             ptr.write_ptr_to_guest(
-//                 &guest_memory
-//                     .ptr::<GuestPtr<u8>>(0)
-//                     .expect("ptr to the first value"),
-//             );
-//             let ptr = guest_memory.ptr_mut(16).expect("ptr mut to first el");
-//             ptr.write_ptr_to_guest(
-//                 &guest_memory
-//                     .ptr::<GuestPtr<u8>>(4)
-//                     .expect("ptr to the second value"),
-//             );
-//             let ptr = guest_memory.ptr_mut(20).expect("ptr mut to first el");
-//             ptr.write_ptr_to_guest(
-//                 &guest_memory
-//                     .ptr::<GuestPtr<u8>>(8)
-//                     .expect("ptr to the third value"),
-//             );
-//         }
-//         // extract as array
-//         let ptr: GuestPtr<GuestPtr<u8>> = guest_memory.ptr(12).expect("ptr to first el");
-//         let arr = ptr.array(3).expect("convert ptr to array");
-//         let contents = arr
-//             .iter()
-//             .map(|ptr_ptr| {
-//                 *ptr_ptr
-//                     .expect("valid ptr to ptr")
-//                     .read_ptr_from_guest()
-//                     .expect("valid ptr to some value")
-//                     .as_ref()
-//                     .expect("deref ptr to some value")
-//             })
-//             .collect::<Vec<_>>();
-//         assert_eq!(&contents, &[255, 254, 253]);
-//     }
-// }
+    #[test]
+    fn invalid_utf8() {
+        let mut host_memory = HostMemory::new();
+        let guest_memory = GuestMemory::new(host_memory.as_mut_ptr(), host_memory.len() as u32);
+        // write string into memory
+        let mut ptr: GuestPtrMut<u8> = guest_memory.ptr_mut(0).expect("ptr mut to start of string");
+        let input_str = "cześć WASI!";
+        let mut bytes = input_str.as_bytes().to_vec();
+        bytes.push(b'\0');
+        // insert 0xFE which is an invalid UTF-8 byte
+        bytes[5] = 0xfe;
+        for byte in bytes {
+            let mut ref_mut = ptr.as_ref_mut().expect("valid deref");
+            *ref_mut = byte;
+            ptr = ptr.elem(1).expect("next ptr");
+        }
+        // read the string as GuestString
+        let ptr: GuestPtr<u8> = guest_memory.ptr(0).expect("ptr to start of string");
+        let guest_string = ptr.string().expect("valid null-terminated string");
+        let as_ref = guest_string.as_ref().expect("deref");
+        assert_eq!(as_ref.as_str(), Err(GuestError::InvalidUtf8));
+    }
+}

--- a/crates/runtime/src/memory/string.rs
+++ b/crates/runtime/src/memory/string.rs
@@ -78,6 +78,7 @@ mod test {
         let guest_memory = GuestMemory::new(host_memory.as_mut_ptr(), host_memory.len() as u32);
         // write string into memory
         let mut ptr: GuestPtrMut<u8> = guest_memory.ptr_mut(0).expect("ptr mut to start of string");
+        // let input_str = "cześć WASI!";
         let input_str = "cześć WASI!";
         for byte in input_str.as_bytes() {
             let mut ref_mut = ptr.as_ref_mut().expect("valid deref");

--- a/crates/runtime/src/memory/string.rs
+++ b/crates/runtime/src/memory/string.rs
@@ -41,7 +41,7 @@ impl<'a> fmt::Debug for GuestStringRef<'a> {
 
 impl<'a> GuestStringRef<'a> {
     pub fn as_str(&self) -> Result<&str, GuestError> {
-        std::str::from_utf8(&*self.ref_).map_err(|_| GuestError::InvalidUtf8)
+        std::str::from_utf8(&*self.ref_).map_err(Into::into)
     }
 }
 
@@ -116,6 +116,9 @@ mod test {
             .expect("valid null-terminated string")
             .into();
         let as_ref = guest_string.as_ref().expect("deref");
-        assert_eq!(as_ref.as_str(), Err(GuestError::InvalidUtf8));
+        match as_ref.as_str().expect_err("should fail") {
+            GuestError::InvalidUtf8(_) => {}
+            x => assert!(false, "expected GuestError::InvalidUtf8(_), got {:?}", x),
+        }
     }
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -136,6 +136,10 @@ impl foo::Foo for WasiCtx {
         })?;
         Ok(old_config ^ other_config)
     }
+
+    fn hello_string(&mut self, a_string: GuestString) -> Result<(), types::Errno> {
+        Ok(())
+    }
 }
 // Errno is used as a first return value in the functions above, therefore
 // it must implement GuestErrorType with type Context = WasiCtx.

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -139,10 +139,8 @@ impl foo::Foo for WasiCtx {
 
     fn hello_string(&mut self, a_string: &GuestString<'_>) -> Result<(), types::Errno> {
         let as_ref = a_string.as_ref().expect("deref ptr should succeed");
-        println!(
-            "a_string='{}'",
-            as_ref.as_str().expect("valid UTF-8 string")
-        );
+        let as_str = as_ref.as_str().expect("valid UTF-8 string");
+        println!("a_string='{}'", as_str);
         Ok(())
     }
 }
@@ -878,17 +876,7 @@ proptest! {
 }
 
 fn test_string_strategy() -> impl Strategy<Value = String> {
-    prop_oneof![
-        "Cześć",
-        "WASI!",
-        "H",
-        "Ho",
-        "How",
-        "Howl",
-        "?!?!?!?!?!",
-        "ąęćśźż",
-    ]
-    .boxed()
+    "\\p{Greek}{1,256}"
 }
 
 #[derive(Debug)]

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -2,7 +2,7 @@ use proptest::prelude::*;
 use std::convert::TryFrom;
 use wiggle_runtime::{
     GuestArray, GuestError, GuestErrorType, GuestMemory, GuestPtr, GuestPtrMut, GuestRef,
-    GuestRefMut,
+    GuestRefMut, GuestString,
 };
 
 wiggle_generate::from_witx!({
@@ -137,7 +137,7 @@ impl foo::Foo for WasiCtx {
         Ok(old_config ^ other_config)
     }
 
-    fn hello_string(&mut self, a_string: GuestString) -> Result<(), types::Errno> {
+    fn hello_string(&mut self, a_string: &GuestString<'_>) -> Result<(), types::Errno> {
         Ok(())
     }
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -138,6 +138,11 @@ impl foo::Foo for WasiCtx {
     }
 
     fn hello_string(&mut self, a_string: &GuestString<'_>) -> Result<(), types::Errno> {
+        let as_ref = a_string.as_ref().expect("deref ptr should succeed");
+        println!(
+            "a_string='{}'",
+            as_ref.as_str().expect("valid UTF-8 string")
+        );
         Ok(())
     }
 }

--- a/tests/test.witx
+++ b/tests/test.witx
@@ -72,4 +72,8 @@
     (result $error $errno)
     (result $new_config $car_config)
   )
+  (@interface func (export "hello_string")
+    (param $a_string string)
+    (result $error $errno)
+  )
 )

--- a/tests/test.witx
+++ b/tests/test.witx
@@ -34,8 +34,6 @@
 (typename $const_excuse_array (array (@witx const_pointer $excuse)))
 (typename $excuse_array (array (@witx pointer $excuse)))
 
-(typename $named_ptr_to_string (@witx const_pointer string))
-
 (module $foo
   (@interface func (export "bar")
     (param $an_int u32)
@@ -77,5 +75,6 @@
   (@interface func (export "hello_string")
     (param $a_string string)
     (result $error $errno)
+    (result $total_bytes u32)
   )
 )

--- a/tests/test.witx
+++ b/tests/test.witx
@@ -34,6 +34,8 @@
 (typename $const_excuse_array (array (@witx const_pointer $excuse)))
 (typename $excuse_array (array (@witx pointer $excuse)))
 
+(typename $named_ptr_to_string (@witx const_pointer string))
+
 (module $foo
   (@interface func (export "bar")
     (param $an_int u32)


### PR DESCRIPTION
This PR adds basic `GuestString` support to `wiggle`. `GuestString`
is a wrapper around `GuestArray<'_, u8>` array type which itself can
be made into either an owned (cloned) Rust `String` or borrowed as
a reference `&str`. In both cases, `GuestString` ensures that the
underlying bytes are valid Unicode code units, throwing a `InvalidUtf8`
error if not.

This PR adds support *only* for passing in strings as arguments
in WASI. Marshalling of the return arg has not yet been implemented.
I'm not even sure it's possible without multi-value return args
feature of Wasm. It's not a major setback especially since the WASI
spec (and this includes even the `ephemeral` snapshot) doesn't
return strings anywhere. They are only ever passed in as arguments
to interface functions.

It should be noted that error returned in case of invalid UTF-8
requires a lot more love as it doesn't include anything besides
flagging an event that the string contained an invalid Unicode code unit.