### PR TITLE
merge GuestTypePtr and GuestTypeClone into a single GuestTypeClone<'a> trait

### DIFF
--- a/crates/generate/src/types.rs
+++ b/crates/generate/src/types.rs
@@ -267,7 +267,7 @@ fn define_enum(names: &Names, name: &witx::Id, e: &witx::EnumDatatype) -> TokenS
         }
 
         impl wiggle_runtime::GuestTypeCopy for #ident {}
-        impl wiggle_runtime::GuestTypeClone for #ident {
+        impl<'a> wiggle_runtime::GuestTypeClone<'a> for #ident {
             fn read_from_guest(location: &wiggle_runtime::GuestPtr<#ident>) -> Result<#ident, wiggle_runtime::GuestError> {
                 use ::std::convert::TryFrom;
                 let raw: #repr = unsafe { (location.as_raw() as *const #repr).read() };
@@ -502,7 +502,7 @@ fn define_ptr_struct(names: &Names, name: &witx::Id, s: &witx::StructDatatype) -
                 Ok(())
             }
         }
-        impl<'a> wiggle_runtime::GuestTypePtr<'a> for #ident<'a> {
+        impl<'a> wiggle_runtime::GuestTypeClone<'a> for #ident<'a> {
             fn read_from_guest(location: &wiggle_runtime::GuestPtr<'a, #ident<'a>>) -> Result<#ident<'a>, wiggle_runtime::GuestError> {
                 #(#member_reads)*
                 Ok(#ident { #(#member_names),* })

--- a/crates/generate/src/types.rs
+++ b/crates/generate/src/types.rs
@@ -179,7 +179,7 @@ fn define_flags(names: &Names, name: &witx::Id, f: &witx::FlagsDatatype) -> Toke
         }
 
         impl wiggle_runtime::GuestTypeCopy for #ident {}
-        impl wiggle_runtime::GuestTypeClone for #ident {
+        impl<'a> wiggle_runtime::GuestTypeClone<'a> for #ident {
             fn read_from_guest(location: &wiggle_runtime::GuestPtr<#ident>) -> Result<#ident, wiggle_runtime::GuestError> {
                 Ok(*location.as_ref()?)
             }

--- a/crates/runtime/src/guest_type.rs
+++ b/crates/runtime/src/guest_type.rs
@@ -11,11 +11,7 @@ pub trait GuestType: Sized {
 }
 
 pub trait GuestTypeCopy: GuestType + Copy {}
-pub trait GuestTypeClone: GuestType + Clone {
-    fn read_from_guest<'a>(location: &GuestPtr<'a, Self>) -> Result<Self, GuestError>;
-    fn write_to_guest<'a>(&self, location: &GuestPtrMut<'a, Self>);
-}
-pub trait GuestTypePtr<'a>: GuestType {
+pub trait GuestTypeClone<'a>: GuestType + Clone {
     fn read_from_guest(location: &GuestPtr<'a, Self>) -> Result<Self, GuestError>;
     fn write_to_guest(&self, location: &GuestPtrMut<'a, Self>);
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -5,6 +5,6 @@ mod memory;
 mod region;
 
 pub use error::GuestError;
-pub use guest_type::{GuestErrorType, GuestType, GuestTypeClone, GuestTypeCopy, GuestTypePtr};
+pub use guest_type::{GuestErrorType, GuestType, GuestTypeClone, GuestTypeCopy};
 pub use memory::{GuestArray, GuestMemory, GuestPtr, GuestPtrMut, GuestRef, GuestRefMut};
 pub use region::Region;

--- a/crates/runtime/src/memory/array.rs
+++ b/crates/runtime/src/memory/array.rs
@@ -1,5 +1,5 @@
 use super::ptr::{GuestPtr, GuestRef};
-use crate::{GuestError, GuestType, GuestTypeClone, GuestTypeCopy};
+use crate::{GuestError, GuestType, GuestTypeCopy};
 use std::{fmt, ops::Deref};
 
 #[derive(Clone)]
@@ -146,9 +146,9 @@ where
 
 #[cfg(test)]
 mod test {
-    use super::super::{
-        ptr::{GuestPtr, GuestPtrMut},
-        GuestError, GuestMemory, Region,
+    use crate::{
+        memory::ptr::{GuestPtr, GuestPtrMut},
+        GuestError, GuestMemory, GuestTypeClone, Region,
     };
 
     #[repr(align(4096))]
@@ -249,9 +249,7 @@ mod test {
         let contents = arr
             .iter()
             .map(|ptr_ptr| {
-                *ptr_ptr
-                    .expect("valid ptr to ptr")
-                    .read_ptr_from_guest()
+                *GuestTypeClone::read_from_guest(&ptr_ptr.expect("valid ptr to ptr"))
                     .expect("valid ptr to some value")
                     .as_ref()
                     .expect("deref ptr to some value")

--- a/crates/runtime/src/memory/array.rs
+++ b/crates/runtime/src/memory/array.rs
@@ -1,7 +1,8 @@
 use super::ptr::{GuestPtr, GuestRef};
-use crate::{GuestError, GuestType, GuestTypeCopy};
+use crate::{GuestError, GuestType, GuestTypeClone, GuestTypeCopy};
 use std::{fmt, ops::Deref};
 
+#[derive(Clone)]
 pub struct GuestArray<'a, T>
 where
     T: GuestType,


### PR DESCRIPTION
Turned out there was no reason for these to be separate traits all along, I just made them separate out of confusion.

