### PR TITLE
Draft out IntDatatype in wiggle-generate

### DIFF
--- a/crates/generate/src/funcs.rs
+++ b/crates/generate/src/funcs.rs
@@ -154,6 +154,7 @@ fn marshal_arg(
     match &*tref.type_() {
         witx::Type::Enum(_e) => try_into_conversion,
         witx::Type::Flags(_f) => try_into_conversion,
+        witx::Type::Int(_i) => try_into_conversion,
         witx::Type::Builtin(b) => match b {
             witx::BuiltinType::U8 | witx::BuiltinType::U16 | witx::BuiltinType::Char8 => {
                 try_into_conversion
@@ -359,7 +360,7 @@ where
             | witx::BuiltinType::Char8 => write_val_to_ptr,
             witx::BuiltinType::String => unimplemented!("string types"),
         },
-        witx::Type::Enum(_) | witx::Type::Flags(_) => write_val_to_ptr,
+        witx::Type::Enum(_) | witx::Type::Flags(_) | witx::Type::Int(_) => write_val_to_ptr,
         _ => unimplemented!("marshal result"),
     }
 }

--- a/crates/generate/src/names.rs
+++ b/crates/generate/src/names.rs
@@ -86,6 +86,10 @@ impl Names {
         format_ident!("{}", id.as_str().to_shouty_snake_case())
     }
 
+    pub fn int_member(&self, id: &Id) -> Ident {
+        format_ident!("{}", id.as_str().to_shouty_snake_case())
+    }
+
     pub fn struct_member(&self, id: &Id) -> Ident {
         format_ident!("{}", id.as_str().to_snake_case())
     }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -143,6 +143,15 @@ impl foo::Foo for WasiCtx {
         println!("a_string='{}'", as_str);
         Ok(as_str.len() as u32)
     }
+
+    fn cookie_cutter(&mut self, init_cookie: types::Cookie) -> Result<types::Bool, types::Errno> {
+        let res = if init_cookie == types::Cookie::START {
+            types::Bool::True
+        } else {
+            types::Bool::False
+        };
+        Ok(res)
+    }
 }
 // Errno is used as a first return value in the functions above, therefore
 // it must implement GuestErrorType with type Context = WasiCtx.
@@ -955,6 +964,65 @@ impl HelloStringExercise {
 proptest! {
     #[test]
     fn hello_string(e in HelloStringExercise::strat()) {
+        e.test()
+    }
+}
+
+fn cookie_strat() -> impl Strategy<Value = types::Cookie> {
+    (0..std::u64::MAX)
+        .prop_map(|x| types::Cookie::try_from(x).expect("within range of cookie"))
+        .boxed()
+}
+
+#[derive(Debug)]
+struct CookieCutterExercise {
+    cookie: types::Cookie,
+    return_ptr_loc: MemArea,
+}
+
+impl CookieCutterExercise {
+    pub fn strat() -> BoxedStrategy<Self> {
+        (cookie_strat(), HostMemory::mem_area_strat(4))
+            .prop_map(|(cookie, return_ptr_loc)| Self {
+                cookie,
+                return_ptr_loc,
+            })
+            .boxed()
+    }
+
+    pub fn test(&self) {
+        let mut ctx = WasiCtx::new();
+        let mut host_memory = HostMemory::new();
+        let mut guest_memory = GuestMemory::new(host_memory.as_mut_ptr(), host_memory.len() as u32);
+
+        let res = foo::cookie_cutter(
+            &mut ctx,
+            &mut guest_memory,
+            self.cookie.into(),
+            self.return_ptr_loc.ptr as i32,
+        );
+        assert_eq!(res, types::Errno::Ok.into(), "cookie cutter errno");
+
+        let is_cookie_start = *guest_memory
+            .ptr::<types::Bool>(self.return_ptr_loc.ptr)
+            .expect("ptr to returned Bool")
+            .as_ref()
+            .expect("deref to Bool value");
+
+        assert_eq!(
+            if is_cookie_start == types::Bool::True {
+                true
+            } else {
+                false
+            },
+            self.cookie == types::Cookie::START,
+            "returned Bool should test if input was Cookie::START",
+        );
+    }
+}
+proptest! {
+    #[test]
+    fn cookie_cutter(e in CookieCutterExercise::strat()) {
         e.test()
     }
 }

--- a/tests/test.witx
+++ b/tests/test.witx
@@ -22,6 +22,11 @@
   (int u64
     (const $start 0)))
 
+(typename $bool
+  (enum u8
+    $false
+    $true))
+
 (typename $pair_ints
   (struct
     (field $first s32)
@@ -80,5 +85,10 @@
     (param $a_string string)
     (result $error $errno)
     (result $total_bytes u32)
+  )
+  (@interface func (export "cookie_cutter")
+    (param $init_cookie $cookie)
+    (result $error $errno)
+    (result $is_start $bool)
   )
 )

--- a/tests/test.witx
+++ b/tests/test.witx
@@ -18,6 +18,10 @@
     $awd
     $suv))
 
+(typename $cookie
+  (int u64
+    (const $start 0)))
+
 (typename $pair_ints
   (struct
     (field $first s32)


### PR DESCRIPTION
This PR drafts out basic layout for `IntDatatype` structure in
`wiggle`. As it currently stands, an `Int` type is represented as
a one-element tuple struct much like `FlagDatatype`, however, with
this difference that we do not perform any checks on the input
underlying representation since any value for the prescribed type
is legal.

This PR also adds necessary marshal stubs to properly pass `IntDatatype`
in and out of interface functions. It also adds a basic proptest.