### PR TITLE
Implement fmt::Display for enums, flags, and ints

### DIFF
--- a/crates/generate/src/types.rs
+++ b/crates/generate/src/types.rs
@@ -72,6 +72,12 @@ fn define_int(names: &Names, name: &witx::Id, i: &witx::IntDatatype) -> TokenStr
             #(#consts;)*
         }
 
+        impl ::std::fmt::Display for #ident {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                write!(f, "{:?}", self)
+            }
+        }
+
         impl ::std::convert::TryFrom<#repr> for #ident {
             type Error = wiggle_runtime::GuestError;
             fn try_from(value: #repr) -> Result<Self, wiggle_runtime::GuestError> {

--- a/crates/generate/src/types.rs
+++ b/crates/generate/src/types.rs
@@ -153,6 +153,8 @@ fn define_flags(names: &Names, name: &witx::Id, f: &witx::FlagsDatatype) -> Toke
     }
     let all_values_token = Literal::u128_unsuffixed(all_values);
 
+    let ident_str = ident.to_string();
+
     quote! {
         #[repr(transparent)]
         #[derive(Copy, Clone, Debug, ::std::hash::Hash, Eq, PartialEq)]
@@ -164,6 +166,12 @@ fn define_flags(names: &Names, name: &witx::Id, f: &witx::FlagsDatatype) -> Toke
 
             pub fn contains(&self, other: &#ident) -> bool {
                 #repr::from(!*self & *other) == 0 as #repr
+            }
+        }
+
+        impl ::std::fmt::Display for #ident {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                write!(f, "{}({:#b})", #ident_str, self.0)
             }
         }
 

--- a/tests/errno.witx
+++ b/tests/errno.witx
@@ -1,8 +1,13 @@
 (typename $errno
     (enum u32
+        ;;; Success
         $ok
+        ;;; Invalid argument
         $invalid_arg
+        ;;; I really don't want to
         $dont_want_to
+        ;;; I am physically unable to
         $physically_unable
+        ;;; Well, that's a picket line alright!
         $picket_line))
 


### PR DESCRIPTION
In preparation for integrating `wiggle` with `wasi-common`, I've started going through the code and noticed that `wasi-common` relies on `strerror` to nicely format error messages (and we actually manually implement similar for `whence`). `strerror` is autoimplemented in `wig`. I thought it might be useful to provide a Rust-idiomatic alternative which boils down to autoimplementing `fmt::Display` for all enums. While doing this, I thought that it might also be useful to provide a default implementation for flags and ints also.