### PR TITLE
Fix read/write for GuestTypeCopy members of non-copy structs

### DIFF
--- a/crates/runtime/src/memory/array.rs
+++ b/crates/runtime/src/memory/array.rs
@@ -79,7 +79,7 @@ where
 
 impl<'a, T> GuestArray<'a, T>
 where
-    T: GuestTypeCopy,
+    T: GuestTypeCopy<'a>,
 {
     pub fn as_ref(&self) -> Result<GuestArrayRef<'a, T>, GuestError> {
         let mut next = self.ptr.elem(0)?;
@@ -109,7 +109,7 @@ where
 
 pub struct GuestArrayRef<'a, T>
 where
-    T: GuestTypeCopy,
+    T: GuestTypeCopy<'a>,
 {
     ref_: GuestRef<'a, T>,
     num_elems: u32,
@@ -117,7 +117,7 @@ where
 
 impl<'a, T> fmt::Debug for GuestArrayRef<'a, T>
 where
-    T: GuestTypeCopy + fmt::Debug,
+    T: GuestTypeCopy<'a> + fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
@@ -130,7 +130,7 @@ where
 
 impl<'a, T> Deref for GuestArrayRef<'a, T>
 where
-    T: GuestTypeCopy,
+    T: GuestTypeCopy<'a>,
 {
     type Target = [T];
 

--- a/crates/runtime/src/memory/ptr.rs
+++ b/crates/runtime/src/memory/ptr.rs
@@ -57,7 +57,7 @@ impl<'a, T: GuestType> GuestPtr<'a, T> {
 
 impl<'a, T> GuestPtr<'a, T>
 where
-    T: GuestTypeCopy,
+    T: GuestTypeCopy<'a>,
 {
     pub fn as_ref(&self) -> Result<GuestRef<'a, T>, GuestError> {
         T::validate(&self)?;
@@ -183,7 +183,7 @@ where
 
 impl<'a, T> GuestPtrMut<'a, T>
 where
-    T: GuestTypeCopy,
+    T: GuestTypeCopy<'a>,
 {
     pub fn as_ref(&self) -> Result<GuestRef<'a, T>, GuestError> {
         self.as_immut().as_ref()
@@ -298,7 +298,7 @@ impl<'a, T> GuestRef<'a, T> {
 
 impl<'a, T> Deref for GuestRef<'a, T>
 where
-    T: GuestTypeCopy,
+    T: GuestTypeCopy<'a>,
 {
     type Target = T;
 
@@ -357,7 +357,7 @@ impl<'a, T> GuestRefMut<'a, T> {
 
 impl<'a, T> ::std::ops::Deref for GuestRefMut<'a, T>
 where
-    T: GuestTypeCopy,
+    T: GuestTypeCopy<'a>,
 {
     type Target = T;
 
@@ -372,7 +372,7 @@ where
 
 impl<'a, T> DerefMut for GuestRefMut<'a, T>
 where
-    T: GuestTypeCopy,
+    T: GuestTypeCopy<'a>,
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe {

--- a/tests/structs.rs
+++ b/tests/structs.rs
@@ -25,6 +25,15 @@ impl structs::Structs for WasiCtx {
             .expect("dereferncing GuestPtr should succeed");
         Ok(first as i64 + second as i64)
     }
+
+    fn sum_of_int_and_ptr(&mut self, an_pair: &types::PairIntAndPtr) -> Result<i64, types::Errno> {
+        let first = *an_pair
+            .first
+            .as_ref()
+            .expect("dereferencing GuestPtr should succeed");
+        let second = an_pair.second as i64;
+        Ok(first as i64 + second)
+    }
 }
 
 #[derive(Debug)]
@@ -197,6 +206,94 @@ impl SumPairPtrsExercise {
 proptest! {
     #[test]
     fn sum_of_pair_of_ptrs(e in SumPairPtrsExercise::strat()) {
+        e.test()
+    }
+}
+
+#[derive(Debug)]
+struct SumIntAndPtrExercise {
+    input_first: i32,
+    input_second: i32,
+    input_first_loc: MemArea,
+    input_struct_loc: MemArea,
+    return_loc: MemArea,
+}
+
+impl SumIntAndPtrExercise {
+    pub fn strat() -> BoxedStrategy<Self> {
+        (
+            prop::num::i32::ANY,
+            prop::num::i32::ANY,
+            HostMemory::mem_area_strat(4),
+            HostMemory::mem_area_strat(8),
+            HostMemory::mem_area_strat(8),
+        )
+            .prop_map(
+                |(input_first, input_second, input_first_loc, input_struct_loc, return_loc)| {
+                    SumIntAndPtrExercise {
+                        input_first,
+                        input_second,
+                        input_first_loc,
+                        input_struct_loc,
+                        return_loc,
+                    }
+                },
+            )
+            .prop_filter("non-overlapping pointers", |e| {
+                MemArea::non_overlapping_set(&[
+                    &e.input_first_loc,
+                    &e.input_struct_loc,
+                    &e.return_loc,
+                ])
+            })
+            .boxed()
+    }
+    pub fn test(&self) {
+        let mut ctx = WasiCtx::new();
+        let mut host_memory = HostMemory::new();
+        let mut guest_memory = host_memory.guest_memory();
+
+        *guest_memory
+            .ptr_mut(self.input_first_loc.ptr)
+            .expect("input_first ptr")
+            .as_ref_mut()
+            .expect("input_first ref") = self.input_first;
+        *guest_memory
+            .ptr_mut(self.input_struct_loc.ptr)
+            .expect("input_struct ptr")
+            .as_ref_mut()
+            .expect("input_struct ref") = self.input_first_loc.ptr;
+        *guest_memory
+            .ptr_mut(self.input_struct_loc.ptr + 4)
+            .expect("input_struct ptr")
+            .as_ref_mut()
+            .expect("input_struct ref") = self.input_second;
+
+        let res = structs::sum_of_int_and_ptr(
+            &mut ctx,
+            &mut guest_memory,
+            self.input_struct_loc.ptr as i32,
+            self.return_loc.ptr as i32,
+        );
+
+        assert_eq!(res, types::Errno::Ok.into(), "sum of int and ptr errno");
+
+        let doubled: i64 = *guest_memory
+            .ptr(self.return_loc.ptr)
+            .expect("return ptr")
+            .as_ref()
+            .expect("return ref");
+
+        assert_eq!(
+            doubled,
+            (self.input_first as i64) + (self.input_second as i64),
+            "sum of pair of ptrs return val"
+        );
+    }
+}
+proptest! {
+    #[test]
+    fn sum_of_int_and_ptr(e in SumIntAndPtrExercise::strat()) {
         e.test()
     }
 }

--- a/tests/structs.witx
+++ b/tests/structs.witx
@@ -11,6 +11,11 @@
     (field $first (@witx const_pointer s32))
     (field $second (@witx const_pointer s32))))
 
+(typename $pair_int_and_ptr
+  (struct
+    (field $first (@witx const_pointer s32))
+    (field $second s32)))
+
 (module $structs
   (@interface func (export "sum_of_pair")
     (param $an_pair $pair_ints)
@@ -20,4 +25,8 @@
     (param $an_pair $pair_int_ptrs)
     (result $error $errno)
     (result $doubled s64))
+  (@interface func (export "sum_of_int_and_ptr")
+    (param $an_pair $pair_int_and_ptr)
+    (result $error $errno)
+    (result $double s64))
 )


### PR DESCRIPTION
This PR fixes stubs for struct members that are `GuestTypeCopy`
but are not `GuestTypeClone`. In this case, we cannot rely on methods
`T::read_from_guest` or `T::write_to_guest` since these are only
available if `T: GuestTypeClone`. In those cases, we can and should
dereference the location pointer to `T` and copy the result in/out
respectively.