### PR TITLE
rename the pointer read/write methods to read and write

### DIFF
--- a/crates/generate/src/funcs.rs
+++ b/crates/generate/src/funcs.rs
@@ -262,8 +262,8 @@ fn marshal_arg(
             let arg_name = names.func_ptr_binding(&param.name);
             let name = names.func_param(&param.name);
             quote! {
-                let #name = match memory.ptr_mut::<#pointee_type>(#arg_name as u32) {
-                    Ok(p) => match p.read_ptr_from_guest() {
+                let #name = match memory.ptr::<#pointee_type>(#arg_name as u32) {
+                    Ok(p) => match p.read() {
                         Ok(r) => r,
                         Err(e) => {
                             #error_handling
@@ -335,7 +335,7 @@ where
         // trait binding returns func_param name.
         let val_name = names.func_param(&result.name);
         let post = quote! {
-            #ptr_name.write_ptr_to_guest(&#val_name);
+            #ptr_name.write(&#val_name);
         };
         (pre, post)
     };

--- a/crates/runtime/src/memory/array.rs
+++ b/crates/runtime/src/memory/array.rs
@@ -225,19 +225,19 @@ mod test {
         }
         {
             let ptr = guest_memory.ptr_mut(12).expect("ptr mut to first el");
-            ptr.write_ptr_to_guest(
+            ptr.write(
                 &guest_memory
                     .ptr::<GuestPtr<u8>>(0)
                     .expect("ptr to the first value"),
             );
             let ptr = guest_memory.ptr_mut(16).expect("ptr mut to first el");
-            ptr.write_ptr_to_guest(
+            ptr.write(
                 &guest_memory
                     .ptr::<GuestPtr<u8>>(4)
                     .expect("ptr to the second value"),
             );
             let ptr = guest_memory.ptr_mut(20).expect("ptr mut to first el");
-            ptr.write_ptr_to_guest(
+            ptr.write(
                 &guest_memory
                     .ptr::<GuestPtr<u8>>(8)
                     .expect("ptr to the third value"),

--- a/crates/runtime/src/memory/ptr.rs
+++ b/crates/runtime/src/memory/ptr.rs
@@ -80,7 +80,7 @@ impl<'a, T> GuestPtr<'a, T>
 where
     T: GuestTypeClone<'a>,
 {
-    pub fn clone_from_guest(&self) -> Result<T, GuestError> {
+    pub fn read(&self) -> Result<T, GuestError> {
         T::read_from_guest(self)
     }
 }
@@ -210,11 +210,11 @@ impl<'a, T> GuestPtrMut<'a, T>
 where
     T: GuestTypeClone<'a>,
 {
-    pub fn read_ptr_from_guest(&self) -> Result<T, GuestError> {
+    pub fn read(&self) -> Result<T, GuestError> {
         T::read_from_guest(&self.as_immut())
     }
 
-    pub fn write_ptr_to_guest(&self, ptr: &T) {
+    pub fn write(&self, ptr: &T) {
         T::write_to_guest(ptr, &self);
     }
 }

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -107,7 +107,7 @@ impl ReduceExcusesExcercise {
                 .ptr_mut(self.array_ptr_loc.ptr)
                 .expect("ptr to array mut");
             for ptr in &self.excuse_ptr_locs {
-                next.write_ptr_to_guest(
+                next.write(
                     &guest_memory
                         .ptr::<types::Excuse>(ptr.ptr)
                         .expect("ptr to Excuse value"),
@@ -203,7 +203,7 @@ impl PopulateExcusesExcercise {
                 .ptr_mut(self.array_ptr_loc.ptr)
                 .expect("ptr mut to the first element of array");
             for ptr in &self.elements {
-                next.write_ptr_to_guest(
+                next.write(
                     &guest_memory
                         .ptr_mut::<types::Excuse>(ptr.ptr)
                         .expect("ptr mut to Excuse value"),

--- a/tests/pointers.rs
+++ b/tests/pointers.rs
@@ -54,7 +54,7 @@ impl pointers::Pointers for WasiCtx {
         println!("input4 {:?}", input4);
 
         // Write ptr value to mutable ptr:
-        input4_ptr_ptr.write_ptr_to_guest(&input2_ptr.as_immut());
+        input4_ptr_ptr.write(&input2_ptr.as_immut());
 
         Ok(())
     }

--- a/tests/structs.rs
+++ b/tests/structs.rs
@@ -428,12 +428,12 @@ impl ReturnPairPtrsExercise {
         let ret_first_ptr: GuestPtr<i32> = ptr_pair_int_ptrs
             .cast::<GuestPtr<i32>>(0u32)
             .expect("extract ptr to first element in struct")
-            .clone_from_guest()
+            .read()
             .expect("read ptr to first element in struct");
         let ret_second_ptr: GuestPtr<i32> = ptr_pair_int_ptrs
             .cast::<GuestPtr<i32>>(4u32)
             .expect("extract ptr to second element in struct")
-            .clone_from_guest()
+            .read()
             .expect("read ptr to second element in struct");
         assert_eq!(
             self.input_first,


### PR DESCRIPTION
these names were artifacts of some early confusion / bad design i made
in the traits. read and write are much simpler names!

also, change a ptr_mut to ptr where we just read the contents in the
argument marshalling for structs. this has no effect, but it is more
correct.

(splitting into a separate PR from #10 to keep that on topic)