### PR TITLE
Add TryFromIntError to GuestError and fix error handling

### DIFF
--- a/crates/generate/src/funcs.rs
+++ b/crates/generate/src/funcs.rs
@@ -62,7 +62,7 @@ pub fn define_func(names: &Names, func: &witx::InterfaceFunc) -> TokenStream {
             };
             let err_typename = names.type_ref(&tref, anon_lifetime());
             quote! {
-                let e = wiggle_runtime::GuestError::InFunc { funcname: #funcname, location: #location, err: Box::new(e) };
+                let e = wiggle_runtime::GuestError::InFunc { funcname: #funcname, location: #location, err: Box::new(e.into()) };
                 let err: #err_typename = wiggle_runtime::GuestErrorType::from_error(e, ctx);
                 return #abi_ret::from(err);
             }

--- a/crates/runtime/src/error.rs
+++ b/crates/runtime/src/error.rs
@@ -27,6 +27,8 @@ pub enum GuestError {
         #[source]
         err: Box<GuestError>,
     },
-    #[error("Invalid UTF-8 encountered")]
-    InvalidUtf8(#[from] std::str::Utf8Error),
+    #[error("Invalid UTF-8 encountered: {0:?}")]
+    InvalidUtf8(#[from] ::std::str::Utf8Error),
+    #[error("Int conversion error: {0:?}")]
+    TryFromIntError(#[from] ::std::num::TryFromIntError),
 }


### PR DESCRIPTION
While working on the full WASI spec, it turned out that we need two
tweaks to `GuestError`:
1. we need to support conversion from `TryFromIntError`, and
2. we need to invoke `e.into()` when unwrapping the result of `try_into()`
   in auto-implementation of raw interface functions.

Both problems seem to originate for "transparent" builtin types since
for those we don't really provide a `TryFrom` implementation like for
compound types, e.g., enums, flags, etc.