### PR TITLE
Unify GuestType and GuestTypeClone, rename GuestTypeCopy to GuestTypeTransparent

### DIFF
--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -5,7 +5,7 @@ mod memory;
 mod region;
 
 pub use error::GuestError;
-pub use guest_type::{GuestErrorType, GuestType, GuestTypeClone, GuestTypeCopy};
+pub use guest_type::{GuestErrorType, GuestType, GuestTypeTransparent};
 pub use memory::{
     GuestArray, GuestMemory, GuestPtr, GuestPtrMut, GuestRef, GuestRefMut, GuestString,
     GuestStringRef,

--- a/crates/runtime/src/memory/mod.rs
+++ b/crates/runtime/src/memory/mod.rs
@@ -43,7 +43,7 @@ impl<'a> GuestMemory<'a> {
             && r.start <= (self.len - r.len)
     }
 
-    pub fn ptr<T: GuestType>(&'a self, at: u32) -> Result<GuestPtr<'a, T>, GuestError> {
+    pub fn ptr<T: GuestType<'a>>(&'a self, at: u32) -> Result<GuestPtr<'a, T>, GuestError> {
         let region = Region {
             start: at,
             len: T::size(),
@@ -61,7 +61,7 @@ impl<'a> GuestMemory<'a> {
         })
     }
 
-    pub fn ptr_mut<T: GuestType>(&'a self, at: u32) -> Result<GuestPtrMut<'a, T>, GuestError> {
+    pub fn ptr_mut<T: GuestType<'a>>(&'a self, at: u32) -> Result<GuestPtrMut<'a, T>, GuestError> {
         let ptr = self.ptr(at)?;
         Ok(GuestPtrMut {
             mem: ptr.mem,

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -1,5 +1,5 @@
 use proptest::prelude::*;
-use wiggle_runtime::{GuestArray, GuestError, GuestPtr, GuestPtrMut};
+use wiggle_runtime::{GuestArray, GuestError, GuestPtr, GuestPtrMut, GuestType};
 use wiggle_test::{impl_errno, HostMemory, MemArea, WasiCtx};
 
 wiggle_generate::from_witx!({
@@ -14,7 +14,7 @@ impl arrays::Arrays for WasiCtx {
         &mut self,
         excuses: &types::ConstExcuseArray,
     ) -> Result<types::Excuse, types::Errno> {
-        let last = wiggle_runtime::GuestTypeClone::read_from_guest(
+        let last = GuestType::read(
             &excuses
                 .iter()
                 .last()
@@ -27,9 +27,8 @@ impl arrays::Arrays for WasiCtx {
 
     fn populate_excuses(&mut self, excuses: &types::ExcuseArray) -> Result<(), types::Errno> {
         for excuse in excuses.iter() {
-            let ptr_to_ptr =
-                wiggle_runtime::GuestTypeClone::read_from_guest(&excuse.expect("valid ptr to ptr"))
-                    .expect("valid ptr to some Excuse value");
+            let ptr_to_ptr = GuestType::read(&excuse.expect("valid ptr to ptr"))
+                .expect("valid ptr to some Excuse value");
             let mut ptr = ptr_to_ptr
                 .as_ref_mut()
                 .expect("dereferencing mut ptr should succeed");
@@ -226,9 +225,8 @@ impl PopulateExcusesExcercise {
             .array(self.elements.len() as u32)
             .expect("as array");
         for el in arr.iter() {
-            let ptr_to_ptr =
-                wiggle_runtime::GuestTypeClone::read_from_guest(&el.expect("valid ptr to ptr"))
-                    .expect("valid ptr to some Excuse value");
+            let ptr_to_ptr = GuestType::read(&el.expect("valid ptr to ptr"))
+                .expect("valid ptr to some Excuse value");
             assert_eq!(
                 *ptr_to_ptr
                     .as_ref()

--- a/tests/pointers.rs
+++ b/tests/pointers.rs
@@ -1,5 +1,5 @@
 use proptest::prelude::*;
-use wiggle_runtime::{GuestError, GuestPtr, GuestPtrMut, GuestRefMut};
+use wiggle_runtime::{GuestError, GuestPtr, GuestPtrMut, GuestRefMut, GuestType};
 use wiggle_test::{impl_errno, HostMemory, MemArea, WasiCtx};
 
 wiggle_generate::from_witx!({
@@ -38,13 +38,11 @@ impl pointers::Pointers for WasiCtx {
         println!("wrote to input2_ref {:?}", input3);
 
         // Read ptr value from mutable ptr:
-        let input4_ptr: GuestPtr<types::Excuse> = wiggle_runtime::GuestTypeClone::read_from_guest(
-            &input4_ptr_ptr.as_immut(),
-        )
-        .map_err(|e| {
-            eprintln!("input4_ptr_ptr error: {}", e);
-            types::Errno::InvalidArg
-        })?;
+        let input4_ptr: GuestPtr<types::Excuse> = GuestType::read(&input4_ptr_ptr.as_immut())
+            .map_err(|e| {
+                eprintln!("input4_ptr_ptr error: {}", e);
+                types::Errno::InvalidArg
+            })?;
 
         // Read enum value from that ptr:
         let input4: types::Excuse = *input4_ptr.as_ref().map_err(|e| {


### PR DESCRIPTION
This commit refactors trait system for guest types. Namely, as
discussed offline on zulip, `GuestType` now includes `GuestTypeClone`,
whereas `GuestTypeCopy` has been renamed to `GuestTypeTransparent`.