### PR TITLE
make `wiggle-generate` an ordinary lib crate, and `wiggle` the `proc-macro` lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,15 @@ version = "0.1.0"
 authors = ["Pat Hickey <phickey@fastly.com>", "Jakub Konka <kubkonk@jakubkonka.com>"]
 edition = "2018"
 
+[lib]
+proc-macro = true
+
 [dependencies]
 wiggle-generate = { path = "crates/generate" }
-wiggle-runtime = { path = "crates/runtime" }
+syn = { version = "1.0", features = ["full"] }
 
 [dev-dependencies]
+wiggle-runtime = { path = "crates/runtime" }
 wiggle-test = { path = "crates/test" }
 proptest = "0.9"
 

--- a/crates/generate/Cargo.toml
+++ b/crates/generate/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Pat Hickey <phickey@fastly.com>", "Jakub Konka <kubkon@jakubkonka.co
 edition = "2018"
 
 [lib]
-proc-macro = true
 
 [dependencies]
 wiggle-runtime = { path = "../runtime" }

--- a/crates/generate/src/lib.rs
+++ b/crates/generate/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate proc_macro;
-
 mod config;
 mod funcs;
 mod lifetimes;
@@ -7,20 +5,16 @@ mod module_trait;
 mod names;
 mod types;
 
-use proc_macro::TokenStream;
+use proc_macro2::TokenStream;
 use quote::quote;
-use syn::parse_macro_input;
 
-use config::Config;
-use funcs::define_func;
-use module_trait::define_module_trait;
-use names::Names;
-use types::define_datatype;
+pub use config::Config;
+pub use funcs::define_func;
+pub use module_trait::define_module_trait;
+pub use names::Names;
+pub use types::define_datatype;
 
-#[proc_macro]
-pub fn from_witx(args: TokenStream) -> TokenStream {
-    let config = parse_macro_input!(args as Config);
-
+pub fn generate(config: Config) -> TokenStream {
     let doc = witx::load(&config.witx.paths).expect("loading witx");
 
     let names = Names::new(config); // TODO parse the names from the invocation of the macro, or from a file?
@@ -43,10 +37,10 @@ pub fn from_witx(args: TokenStream) -> TokenStream {
         )
     });
 
-    TokenStream::from(quote!(
+    quote!(
         mod types {
             #(#types)*
         }
         #(#modules)*
-    ))
+    )
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,10 @@
-/*
-pub mod wasi {
-    generate::from_witx!("crates/WASI/phases/snapshot/witx/wasi_snapshot_preview1.witx");
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use syn::parse_macro_input;
+
+#[proc_macro]
+pub fn from_witx(args: TokenStream) -> TokenStream {
+    let config = parse_macro_input!(args as wiggle_generate::Config);
+    TokenStream::from(wiggle_generate::generate(config))
 }
-*/

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -2,7 +2,7 @@ use proptest::prelude::*;
 use wiggle_runtime::{GuestArray, GuestError, GuestPtr, GuestPtrMut, GuestType};
 use wiggle_test::{impl_errno, HostMemory, MemArea, WasiCtx};
 
-wiggle_generate::from_witx!({
+wiggle::from_witx!({
     witx: ["tests/arrays.witx"],
     ctx: WasiCtx,
 });

--- a/tests/atoms.rs
+++ b/tests/atoms.rs
@@ -2,7 +2,7 @@ use proptest::prelude::*;
 use wiggle_runtime::{GuestError, GuestRef};
 use wiggle_test::{impl_errno, HostMemory, MemArea, WasiCtx};
 
-wiggle_generate::from_witx!({
+wiggle::from_witx!({
     witx: ["tests/atoms.witx"],
     ctx: WasiCtx,
 });

--- a/tests/flags.rs
+++ b/tests/flags.rs
@@ -3,7 +3,7 @@ use std::convert::TryFrom;
 use wiggle_runtime::{GuestError, GuestPtr};
 use wiggle_test::{impl_errno, HostMemory, MemArea, WasiCtx};
 
-wiggle_generate::from_witx!({
+wiggle::from_witx!({
     witx: ["tests/flags.witx"],
     ctx: WasiCtx,
 });

--- a/tests/handles.rs
+++ b/tests/handles.rs
@@ -4,7 +4,7 @@ use wiggle_test::{impl_errno, HostMemory, MemArea, WasiCtx};
 
 const FD_VAL: u32 = 123;
 
-wiggle_generate::from_witx!({
+wiggle::from_witx!({
     witx: ["tests/handles.witx"],
     ctx: WasiCtx,
 });

--- a/tests/ints.rs
+++ b/tests/ints.rs
@@ -3,7 +3,7 @@ use std::convert::TryFrom;
 use wiggle_runtime::GuestError;
 use wiggle_test::{impl_errno, HostMemory, MemArea, WasiCtx};
 
-wiggle_generate::from_witx!({
+wiggle::from_witx!({
     witx: ["tests/ints.witx"],
     ctx: WasiCtx,
 });

--- a/tests/pointers.rs
+++ b/tests/pointers.rs
@@ -2,7 +2,7 @@ use proptest::prelude::*;
 use wiggle_runtime::{GuestError, GuestPtr, GuestPtrMut, GuestRefMut, GuestType};
 use wiggle_test::{impl_errno, HostMemory, MemArea, WasiCtx};
 
-wiggle_generate::from_witx!({
+wiggle::from_witx!({
     witx: ["tests/pointers.witx"],
     ctx: WasiCtx,
 });

--- a/tests/strings.rs
+++ b/tests/strings.rs
@@ -2,7 +2,7 @@ use proptest::prelude::*;
 use wiggle_runtime::{GuestError, GuestPtrMut, GuestString};
 use wiggle_test::{impl_errno, HostMemory, MemArea, WasiCtx};
 
-wiggle_generate::from_witx!({
+wiggle::from_witx!({
     witx: ["tests/strings.witx"],
     ctx: WasiCtx,
 });

--- a/tests/structs.rs
+++ b/tests/structs.rs
@@ -2,7 +2,7 @@ use proptest::prelude::*;
 use wiggle_runtime::{GuestError, GuestPtr};
 use wiggle_test::{impl_errno, HostMemory, MemArea, WasiCtx};
 
-wiggle_generate::from_witx!({
+wiggle::from_witx!({
     witx: ["tests/structs.witx"],
     ctx: WasiCtx,
 });

--- a/tests/union.rs
+++ b/tests/union.rs
@@ -2,7 +2,7 @@ use proptest::prelude::*;
 use wiggle_runtime::{GuestError, GuestType};
 use wiggle_test::{impl_errno, HostMemory, MemArea, WasiCtx};
 
-wiggle_generate::from_witx!({
+wiggle::from_witx!({
     witx: ["tests/union.witx"],
     ctx: WasiCtx,
 });


### PR DESCRIPTION
this allows us to reuse the code in wiggle-generate elsewhere, because a `proc-macro=true` crate can only export `#[proc_macro]` functions, and not ordinary functions.

In lucet, I will depend on wiggle-generate to define a proc macro that glues wiggle to the specifics of the runtime.