### PR TITLE
depend on witx 0.8.3, rather than a path dependency.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "crates/WASI"]
-	path = crates/WASI
-	url = https://github.com/webassembly/wasi.git

--- a/crates/generate/Cargo.toml
+++ b/crates/generate/Cargo.toml
@@ -9,7 +9,7 @@ proc-macro = true
 
 [dependencies]
 wiggle-runtime = { path = "../runtime" }
-witx = { path = "../WASI/tools/witx" }
+witx = "0.8.3"
 quote = "1.0"
 proc-macro2 = "1.0"
 heck = "0.3"


### PR DESCRIPTION
and delete the WASI submodule that was providing the path dep