### PR TITLE
Make generated modules public

### DIFF
--- a/crates/generate/src/lib.rs
+++ b/crates/generate/src/lib.rs
@@ -27,7 +27,7 @@ pub fn generate(config: Config) -> TokenStream {
         let modtrait = define_module_trait(&names, &module);
         let ctx_type = names.ctx_type();
         quote!(
-            mod #modname {
+            pub mod #modname {
                 use super::#ctx_type;
                 use super::types::*;
                 #(#fs)*
@@ -38,7 +38,7 @@ pub fn generate(config: Config) -> TokenStream {
     });
 
     quote!(
-        mod types {
+        pub mod types {
             #(#types)*
         }
         #(#modules)*


### PR DESCRIPTION
While public might be an overkill, until we successfully merge
`wiggle` with `wasi-common` (and others), I suggest we just make
the modules fully public and work from there.