### PR TITLE
Return *mut u8 in GuestPtrMut::as_raw

### DIFF
--- a/crates/runtime/src/memory/ptr.rs
+++ b/crates/runtime/src/memory/ptr.rs
@@ -162,8 +162,8 @@ where
         }
     }
 
-    pub fn as_raw(&self) -> *const u8 {
-        self.as_immut().as_raw()
+    pub fn as_raw(&self) -> *mut u8 {
+        (self.mem.ptr as usize + self.region.start as usize) as *mut u8
     }
 
     pub fn elem(&self, elements: i32) -> Result<Self, GuestError> {


### PR DESCRIPTION
Currently, we create an immutable `GuestPtr` from `self` and call
`as_raw` on it which correctly returns `*const u8`. However, since
we're dealing with `GuestPtrMut` I thought it might make more sense
to return `*mut u8` directly instead. This will be needed (and will
save us from silly casts `*const _ as *mut _`) in plugging in
`Iovec<'_>` into `std::io::IoSliceMut` in `fd_read` and `fd_pread` calls.