### PR TITLE
Minor refactors to make wiggle-generate reusable externally

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ proc-macro = true
 
 [dependencies]
 wiggle-generate = { path = "crates/generate" }
+witx = "0.8.3"
 syn = { version = "1.0", features = ["full"] }
 
 [dev-dependencies]

--- a/crates/generate/src/funcs.rs
+++ b/crates/generate/src/funcs.rs
@@ -11,22 +11,10 @@ pub fn define_func(names: &Names, func: &witx::InterfaceFunc) -> TokenStream {
     let ctx_type = names.ctx_type();
     let coretype = func.core_type();
 
-    let params = coretype.args.iter().map(|arg| match arg.signifies {
-        witx::CoreParamSignifies::Value(atom) => {
-            let atom = names.atom_type(atom);
-            let name = names.func_param(&arg.param.name);
-            quote!(#name : #atom)
-        }
-        witx::CoreParamSignifies::PointerTo => {
-            let atom = names.atom_type(witx::AtomType::I32);
-            let name = names.func_ptr_binding(&arg.param.name);
-            quote!(#name: #atom)
-        }
-        witx::CoreParamSignifies::LengthOf => {
-            let atom = names.atom_type(witx::AtomType::I32);
-            let name = names.func_len_binding(&arg.param.name);
-            quote!(#name: #atom)
-        }
+    let params = coretype.args.iter().map(|arg| {
+        let name = names.func_core_arg(arg);
+        let atom = names.atom_type(arg.repr());
+        quote!(#name : #atom)
     });
 
     let abi_args = quote!(

--- a/crates/generate/src/lib.rs
+++ b/crates/generate/src/lib.rs
@@ -14,9 +14,7 @@ pub use module_trait::define_module_trait;
 pub use names::Names;
 pub use types::define_datatype;
 
-pub fn generate(config: Config) -> TokenStream {
-    let doc = witx::load(&config.witx.paths).expect("loading witx");
-
+pub fn generate(doc: &witx::Document, config: &Config) -> TokenStream {
     let names = Names::new(config); // TODO parse the names from the invocation of the macro, or from a file?
 
     let types = doc.typenames().map(|t| define_datatype(&names, &t));

--- a/crates/generate/src/names.rs
+++ b/crates/generate/src/names.rs
@@ -12,8 +12,10 @@ pub struct Names {
 }
 
 impl Names {
-    pub fn new(config: Config) -> Names {
-        Names { config }
+    pub fn new(config: &Config) -> Names {
+        Names {
+            config: config.clone(),
+        }
     }
     pub fn ctx_type(&self) -> Ident {
         self.config.ctx.name.clone()
@@ -115,6 +117,14 @@ impl Names {
             format_ident!("in_")
         } else {
             format_ident!("{}", id.as_str().to_snake_case())
+        }
+    }
+
+    pub fn func_core_arg(&self, arg: &witx::CoreParamType) -> Ident {
+        match arg.signifies {
+            witx::CoreParamSignifies::Value { .. } => self.func_param(&arg.param.name),
+            witx::CoreParamSignifies::PointerTo => self.func_ptr_binding(&arg.param.name),
+            witx::CoreParamSignifies::LengthOf => self.func_len_binding(&arg.param.name),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,5 +6,6 @@ use syn::parse_macro_input;
 #[proc_macro]
 pub fn from_witx(args: TokenStream) -> TokenStream {
     let config = parse_macro_input!(args as wiggle_generate::Config);
-    TokenStream::from(wiggle_generate::generate(config))
+    let doc = witx::load(&config.witx.paths).expect("loading witx");
+    TokenStream::from(wiggle_generate::generate(&doc, config))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,5 +7,5 @@ use syn::parse_macro_input;
 pub fn from_witx(args: TokenStream) -> TokenStream {
     let config = parse_macro_input!(args as wiggle_generate::Config);
     let doc = witx::load(&config.witx.paths).expect("loading witx");
-    TokenStream::from(wiggle_generate::generate(&doc, config))
+    TokenStream::from(wiggle_generate::generate(&doc, &config))
 }


### PR DESCRIPTION
For https://github.com/bytecodealliance/lucet/pull/439

- separate witx loading from code generation
- some minor code reuse for param names