### PR TITLE
Put context object behind a ref rather than mut ref

### DIFF
--- a/crates/generate/src/module_trait.rs
+++ b/crates/generate/src/module_trait.rs
@@ -39,9 +39,9 @@ pub fn define_module_trait(names: &Names, m: &Module) -> TokenStream {
             .unwrap_or(quote!(()));
 
         if is_anonymous {
-            quote!(fn #funcname(&mut self, #(#args),*) -> Result<(#(#rets),*), #err>;)
+            quote!(fn #funcname(&self, #(#args),*) -> Result<(#(#rets),*), #err>;)
         } else {
-            quote!(fn #funcname<#lifetime>(&mut self, #(#args),*) -> Result<(#(#rets),*), #err>;)
+            quote!(fn #funcname<#lifetime>(&self, #(#args),*) -> Result<(#(#rets),*), #err>;)
         }
     });
     quote! {

--- a/crates/runtime/src/guest_type.rs
+++ b/crates/runtime/src/guest_type.rs
@@ -50,5 +50,5 @@ builtin_type!(u8, i8, u16, i16, u32, i32, u64, i64, f32, f64, usize);
 pub trait GuestErrorType {
     type Context;
     fn success() -> Self;
-    fn from_error(e: GuestError, ctx: &mut Self::Context) -> Self;
+    fn from_error(e: GuestError, ctx: &Self::Context) -> Self;
 }

--- a/crates/test/src/lib.rs
+++ b/crates/test/src/lib.rs
@@ -91,16 +91,17 @@ mod test {
     }
 }
 
+use std::cell::RefCell;
 use wiggle_runtime::GuestError;
 
 pub struct WasiCtx {
-    pub guest_errors: Vec<GuestError>,
+    pub guest_errors: RefCell<Vec<GuestError>>,
 }
 
 impl WasiCtx {
     pub fn new() -> Self {
         Self {
-            guest_errors: vec![],
+            guest_errors: RefCell::new(vec![]),
         }
     }
 }
@@ -117,9 +118,9 @@ macro_rules! impl_errno {
             fn success() -> $errno {
                 <$errno>::Ok
             }
-            fn from_error(e: GuestError, ctx: &mut WasiCtx) -> $errno {
+            fn from_error(e: GuestError, ctx: &WasiCtx) -> $errno {
                 eprintln!("GUEST ERROR: {:?}", e);
-                ctx.guest_errors.push(e);
+                ctx.guest_errors.borrow_mut().push(e);
                 types::Errno::InvalidArg
             }
         }

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -11,7 +11,7 @@ impl_errno!(types::Errno);
 
 impl arrays::Arrays for WasiCtx {
     fn reduce_excuses(
-        &mut self,
+        &self,
         excuses: &types::ConstExcuseArray,
     ) -> Result<types::Excuse, types::Errno> {
         let last = GuestType::read(
@@ -25,7 +25,7 @@ impl arrays::Arrays for WasiCtx {
         Ok(*last.as_ref().expect("dereferencing ptr should succeed"))
     }
 
-    fn populate_excuses(&mut self, excuses: &types::ExcuseArray) -> Result<(), types::Errno> {
+    fn populate_excuses(&self, excuses: &types::ExcuseArray) -> Result<(), types::Errno> {
         for excuse in excuses.iter() {
             let ptr_to_ptr = GuestType::read(&excuse.expect("valid ptr to ptr"))
                 .expect("valid ptr to some Excuse value");

--- a/tests/atoms.rs
+++ b/tests/atoms.rs
@@ -10,14 +10,11 @@ wiggle::from_witx!({
 impl_errno!(types::Errno);
 
 impl atoms::Atoms for WasiCtx {
-    fn int_float_args(&mut self, an_int: u32, an_float: f32) -> Result<(), types::Errno> {
+    fn int_float_args(&self, an_int: u32, an_float: f32) -> Result<(), types::Errno> {
         println!("INT FLOAT ARGS: {} {}", an_int, an_float);
         Ok(())
     }
-    fn double_int_return_float(
-        &mut self,
-        an_int: u32,
-    ) -> Result<types::AliasToFloat, types::Errno> {
+    fn double_int_return_float(&self, an_int: u32) -> Result<types::AliasToFloat, types::Errno> {
         Ok((an_int as f32) * 2.0)
     }
 }

--- a/tests/flags.rs
+++ b/tests/flags.rs
@@ -12,7 +12,7 @@ impl_errno!(types::Errno);
 
 impl flags::Flags for WasiCtx {
     fn configure_car(
-        &mut self,
+        &self,
         old_config: types::CarConfig,
         other_config_ptr: GuestPtr<types::CarConfig>,
     ) -> Result<types::CarConfig, types::Errno> {

--- a/tests/handles.rs
+++ b/tests/handles.rs
@@ -12,10 +12,10 @@ wiggle::from_witx!({
 impl_errno!(types::Errno);
 
 impl handle_examples::HandleExamples for WasiCtx {
-    fn fd_create(&mut self) -> Result<types::Fd, types::Errno> {
+    fn fd_create(&self) -> Result<types::Fd, types::Errno> {
         Ok(types::Fd::from(FD_VAL))
     }
-    fn fd_consume(&mut self, fd: types::Fd) -> Result<(), types::Errno> {
+    fn fd_consume(&self, fd: types::Fd) -> Result<(), types::Errno> {
         println!("FD_CONSUME {}", fd);
         if fd == types::Fd::from(FD_VAL) {
             Ok(())

--- a/tests/ints.rs
+++ b/tests/ints.rs
@@ -11,7 +11,7 @@ wiggle::from_witx!({
 impl_errno!(types::Errno);
 
 impl ints::Ints for WasiCtx {
-    fn cookie_cutter(&mut self, init_cookie: types::Cookie) -> Result<types::Bool, types::Errno> {
+    fn cookie_cutter(&self, init_cookie: types::Cookie) -> Result<types::Bool, types::Errno> {
         let res = if init_cookie == types::Cookie::START {
             types::Bool::True
         } else {

--- a/tests/pointers.rs
+++ b/tests/pointers.rs
@@ -11,7 +11,7 @@ impl_errno!(types::Errno);
 
 impl pointers::Pointers for WasiCtx {
     fn pointers_and_enums(
-        &mut self,
+        &self,
         input1: types::Excuse,
         input2_ptr: GuestPtrMut<types::Excuse>,
         input3_ptr: GuestPtr<types::Excuse>,

--- a/tests/strings.rs
+++ b/tests/strings.rs
@@ -10,7 +10,7 @@ wiggle::from_witx!({
 impl_errno!(types::Errno);
 
 impl strings::Strings for WasiCtx {
-    fn hello_string(&mut self, a_string: &GuestString<'_>) -> Result<u32, types::Errno> {
+    fn hello_string(&self, a_string: &GuestString<'_>) -> Result<u32, types::Errno> {
         let as_ref = a_string.as_ref().expect("deref ptr should succeed");
         let as_str = as_ref.as_str().expect("valid UTF-8 string");
         println!("a_string='{}'", as_str);

--- a/tests/structs.rs
+++ b/tests/structs.rs
@@ -10,11 +10,11 @@ wiggle::from_witx!({
 impl_errno!(types::Errno);
 
 impl structs::Structs for WasiCtx {
-    fn sum_of_pair(&mut self, an_pair: &types::PairInts) -> Result<i64, types::Errno> {
+    fn sum_of_pair(&self, an_pair: &types::PairInts) -> Result<i64, types::Errno> {
         Ok(an_pair.first as i64 + an_pair.second as i64)
     }
 
-    fn sum_of_pair_of_ptrs(&mut self, an_pair: &types::PairIntPtrs) -> Result<i64, types::Errno> {
+    fn sum_of_pair_of_ptrs(&self, an_pair: &types::PairIntPtrs) -> Result<i64, types::Errno> {
         let first = *an_pair
             .first
             .as_ref()
@@ -26,7 +26,7 @@ impl structs::Structs for WasiCtx {
         Ok(first as i64 + second as i64)
     }
 
-    fn sum_of_int_and_ptr(&mut self, an_pair: &types::PairIntAndPtr) -> Result<i64, types::Errno> {
+    fn sum_of_int_and_ptr(&self, an_pair: &types::PairIntAndPtr) -> Result<i64, types::Errno> {
         let first = *an_pair
             .first
             .as_ref()
@@ -35,7 +35,7 @@ impl structs::Structs for WasiCtx {
         Ok(first as i64 + second)
     }
 
-    fn return_pair_ints(&mut self) -> Result<types::PairInts, types::Errno> {
+    fn return_pair_ints(&self) -> Result<types::PairInts, types::Errno> {
         Ok(types::PairInts {
             first: 10,
             second: 20,
@@ -43,7 +43,7 @@ impl structs::Structs for WasiCtx {
     }
 
     fn return_pair_of_ptrs<'a>(
-        &mut self,
+        &self,
         first: GuestPtr<'a, i32>,
         second: GuestPtr<'a, i32>,
     ) -> Result<types::PairIntPtrs<'a>, types::Errno> {

--- a/tests/union.rs
+++ b/tests/union.rs
@@ -32,7 +32,7 @@ fn mult_zero_nan(a: f32, b: u32) -> f32 {
 }
 
 impl union_example::UnionExample for WasiCtx {
-    fn get_tag(&mut self, u: &types::Reason) -> Result<types::Excuse, types::Errno> {
+    fn get_tag(&self, u: &types::Reason) -> Result<types::Excuse, types::Errno> {
         println!("GET TAG: {:?}", u);
         match u {
             types::Reason::DogAte { .. } => Ok(types::Excuse::DogAte),
@@ -40,11 +40,7 @@ impl union_example::UnionExample for WasiCtx {
             types::Reason::Sleeping { .. } => Ok(types::Excuse::Sleeping),
         }
     }
-    fn reason_mult(
-        &mut self,
-        u: &types::ReasonMut<'_>,
-        multiply_by: u32,
-    ) -> Result<(), types::Errno> {
+    fn reason_mult(&self, u: &types::ReasonMut<'_>, multiply_by: u32) -> Result<(), types::Errno> {
         match u {
             types::ReasonMut::DogAte(fptr) => {
                 let mut f = fptr.as_ref_mut().expect("valid pointer");

--- a/tests/wasi.rs
+++ b/tests/wasi.rs
@@ -10,47 +10,49 @@ type Result<T> = std::result::Result<T, types::Errno>;
 
 impl GuestErrorType for types::Errno {
     type Context = WasiCtx;
+
     fn success() -> types::Errno {
         types::Errno::Success
     }
-    fn from_error(e: GuestError, ctx: &mut WasiCtx) -> types::Errno {
+
+    fn from_error(e: GuestError, ctx: &WasiCtx) -> types::Errno {
         eprintln!("GUEST ERROR: {:?}", e);
-        ctx.guest_errors.push(e);
+        ctx.guest_errors.borrow_mut().push(e);
         types::Errno::Io
     }
 }
 
 impl crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
     fn args_get(
-        &mut self,
+        &self,
         _argv: GuestPtrMut<GuestPtrMut<u8>>,
         _argv_buf: GuestPtrMut<u8>,
     ) -> Result<()> {
         unimplemented!("args_get")
     }
 
-    fn args_sizes_get(&mut self) -> Result<(types::Size, types::Size)> {
+    fn args_sizes_get(&self) -> Result<(types::Size, types::Size)> {
         unimplemented!("args_sizes_get")
     }
 
     fn environ_get(
-        &mut self,
+        &self,
         _environ: GuestPtrMut<GuestPtrMut<u8>>,
         _environ_buf: GuestPtrMut<u8>,
     ) -> Result<()> {
         unimplemented!("environ_get")
     }
 
-    fn environ_sizes_get(&mut self) -> Result<(types::Size, types::Size)> {
+    fn environ_sizes_get(&self) -> Result<(types::Size, types::Size)> {
         unimplemented!("environ_sizes_get")
     }
 
-    fn clock_res_get(&mut self, _id: types::Clockid) -> Result<types::Timestamp> {
+    fn clock_res_get(&self, _id: types::Clockid) -> Result<types::Timestamp> {
         unimplemented!("clock_res_get")
     }
 
     fn clock_time_get(
-        &mut self,
+        &self,
         _id: types::Clockid,
         _precision: types::Timestamp,
     ) -> Result<types::Timestamp> {
@@ -58,7 +60,7 @@ impl crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
     }
 
     fn fd_advise(
-        &mut self,
+        &self,
         _fd: types::Fd,
         _offset: types::Filesize,
         _len: types::Filesize,
@@ -68,7 +70,7 @@ impl crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
     }
 
     fn fd_allocate(
-        &mut self,
+        &self,
         _fd: types::Fd,
         _offset: types::Filesize,
         _len: types::Filesize,
@@ -76,24 +78,24 @@ impl crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
         unimplemented!("fd_allocate")
     }
 
-    fn fd_close(&mut self, _fd: types::Fd) -> Result<()> {
+    fn fd_close(&self, _fd: types::Fd) -> Result<()> {
         unimplemented!("fd_close")
     }
 
-    fn fd_datasync(&mut self, _fd: types::Fd) -> Result<()> {
+    fn fd_datasync(&self, _fd: types::Fd) -> Result<()> {
         unimplemented!("fd_datasync")
     }
 
-    fn fd_fdstat_get(&mut self, _fd: types::Fd) -> Result<types::Fdstat> {
+    fn fd_fdstat_get(&self, _fd: types::Fd) -> Result<types::Fdstat> {
         unimplemented!("fd_fdstat_get")
     }
 
-    fn fd_fdstat_set_flags(&mut self, _fd: types::Fd, _flags: types::Fdflags) -> Result<()> {
+    fn fd_fdstat_set_flags(&self, _fd: types::Fd, _flags: types::Fdflags) -> Result<()> {
         unimplemented!("fd_fdstat_set_flags")
     }
 
     fn fd_fdstat_set_rights(
-        &mut self,
+        &self,
         _fd: types::Fd,
         _fs_rights_base: types::Rights,
         _fs_rights_inherting: types::Rights,
@@ -101,16 +103,16 @@ impl crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
         unimplemented!("fd_fdstat_set_rights")
     }
 
-    fn fd_filestat_get(&mut self, _fd: types::Fd) -> Result<types::Filestat> {
+    fn fd_filestat_get(&self, _fd: types::Fd) -> Result<types::Filestat> {
         unimplemented!("fd_filestat_get")
     }
 
-    fn fd_filestat_set_size(&mut self, _fd: types::Fd, _size: types::Filesize) -> Result<()> {
+    fn fd_filestat_set_size(&self, _fd: types::Fd, _size: types::Filesize) -> Result<()> {
         unimplemented!("fd_filestat_set_size")
     }
 
     fn fd_filestat_set_times(
-        &mut self,
+        &self,
         _fd: types::Fd,
         _atim: types::Timestamp,
         _mtim: types::Timestamp,
@@ -120,7 +122,7 @@ impl crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
     }
 
     fn fd_pread(
-        &mut self,
+        &self,
         _fd: types::Fd,
         _iovs: &types::IovecArray<'_>,
         _offset: types::Filesize,
@@ -128,12 +130,12 @@ impl crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
         unimplemented!("fd_pread")
     }
 
-    fn fd_prestat_get(&mut self, _fd: types::Fd) -> Result<types::Prestat> {
+    fn fd_prestat_get(&self, _fd: types::Fd) -> Result<types::Prestat> {
         unimplemented!("fd_prestat_get")
     }
 
     fn fd_prestat_dir_name(
-        &mut self,
+        &self,
         _fd: types::Fd,
         _path: GuestPtrMut<u8>,
         _path_len: types::Size,
@@ -142,7 +144,7 @@ impl crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
     }
 
     fn fd_pwrite(
-        &mut self,
+        &self,
         _fd: types::Fd,
         _ciovs: &types::CiovecArray<'_>,
         _offset: types::Filesize,
@@ -150,12 +152,12 @@ impl crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
         unimplemented!("fd_pwrite")
     }
 
-    fn fd_read(&mut self, _fd: types::Fd, _iovs: &types::IovecArray<'_>) -> Result<types::Size> {
+    fn fd_read(&self, _fd: types::Fd, _iovs: &types::IovecArray<'_>) -> Result<types::Size> {
         unimplemented!("fd_read")
     }
 
     fn fd_readdir(
-        &mut self,
+        &self,
         _fd: types::Fd,
         _buf: GuestPtrMut<u8>,
         _buf_len: types::Size,
@@ -164,12 +166,12 @@ impl crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
         unimplemented!("fd_readdir")
     }
 
-    fn fd_renumber(&mut self, _fd: types::Fd, _to: types::Fd) -> Result<()> {
+    fn fd_renumber(&self, _fd: types::Fd, _to: types::Fd) -> Result<()> {
         unimplemented!("fd_renumber")
     }
 
     fn fd_seek(
-        &mut self,
+        &self,
         _fd: types::Fd,
         _offset: types::Filedelta,
         _whence: types::Whence,
@@ -177,24 +179,24 @@ impl crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
         unimplemented!("fd_seek")
     }
 
-    fn fd_sync(&mut self, _fd: types::Fd) -> Result<()> {
+    fn fd_sync(&self, _fd: types::Fd) -> Result<()> {
         unimplemented!("fd_sync")
     }
 
-    fn fd_tell(&mut self, _fd: types::Fd) -> Result<types::Filesize> {
+    fn fd_tell(&self, _fd: types::Fd) -> Result<types::Filesize> {
         unimplemented!("fd_tell")
     }
 
-    fn fd_write(&mut self, _fd: types::Fd, _ciovs: &types::CiovecArray<'_>) -> Result<types::Size> {
+    fn fd_write(&self, _fd: types::Fd, _ciovs: &types::CiovecArray<'_>) -> Result<types::Size> {
         unimplemented!("fd_write")
     }
 
-    fn path_create_directory(&mut self, _fd: types::Fd, _path: &GuestString<'_>) -> Result<()> {
+    fn path_create_directory(&self, _fd: types::Fd, _path: &GuestString<'_>) -> Result<()> {
         unimplemented!("path_create_directory")
     }
 
     fn path_filestat_get(
-        &mut self,
+        &self,
         _fd: types::Fd,
         _flags: types::Lookupflags,
         _path: &GuestString<'_>,
@@ -203,7 +205,7 @@ impl crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
     }
 
     fn path_filestat_set_times(
-        &mut self,
+        &self,
         _fd: types::Fd,
         _flags: types::Lookupflags,
         _path: &GuestString<'_>,
@@ -215,7 +217,7 @@ impl crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
     }
 
     fn path_link(
-        &mut self,
+        &self,
         _old_fd: types::Fd,
         _old_flags: types::Lookupflags,
         _old_path: &GuestString<'_>,
@@ -226,7 +228,7 @@ impl crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
     }
 
     fn path_open(
-        &mut self,
+        &self,
         _fd: types::Fd,
         _dirflags: types::Lookupflags,
         _path: &GuestString<'_>,
@@ -239,7 +241,7 @@ impl crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
     }
 
     fn path_readlink(
-        &mut self,
+        &self,
         _fd: types::Fd,
         _path: &GuestString<'_>,
         _buf: GuestPtrMut<u8>,
@@ -248,12 +250,12 @@ impl crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
         unimplemented!("path_readlink")
     }
 
-    fn path_remove_directory(&mut self, _fd: types::Fd, _path: &GuestString<'_>) -> Result<()> {
+    fn path_remove_directory(&self, _fd: types::Fd, _path: &GuestString<'_>) -> Result<()> {
         unimplemented!("path_remove_directory")
     }
 
     fn path_rename(
-        &mut self,
+        &self,
         _fd: types::Fd,
         _old_path: &GuestString<'_>,
         _new_fd: types::Fd,
@@ -263,7 +265,7 @@ impl crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
     }
 
     fn path_symlink(
-        &mut self,
+        &self,
         _old_path: &GuestString<'_>,
         _fd: types::Fd,
         _new_path: &GuestString<'_>,
@@ -271,12 +273,12 @@ impl crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
         unimplemented!("path_symlink")
     }
 
-    fn path_unlink_file(&mut self, _fd: types::Fd, _path: &GuestString<'_>) -> Result<()> {
+    fn path_unlink_file(&self, _fd: types::Fd, _path: &GuestString<'_>) -> Result<()> {
         unimplemented!("path_unlink_file")
     }
 
     fn poll_oneoff(
-        &mut self,
+        &self,
         _in_: GuestPtr<types::Subscription>,
         _out: GuestPtrMut<types::Event>,
         _nsubscriptions: types::Size,
@@ -284,24 +286,24 @@ impl crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
         unimplemented!("poll_oneoff")
     }
 
-    fn proc_exit(&mut self, _rval: types::Exitcode) -> std::result::Result<(), ()> {
+    fn proc_exit(&self, _rval: types::Exitcode) -> std::result::Result<(), ()> {
         unimplemented!("proc_exit")
     }
 
-    fn proc_raise(&mut self, _sig: types::Signal) -> Result<()> {
+    fn proc_raise(&self, _sig: types::Signal) -> Result<()> {
         unimplemented!("proc_raise")
     }
 
-    fn sched_yield(&mut self) -> Result<()> {
+    fn sched_yield(&self) -> Result<()> {
         unimplemented!("sched_yield")
     }
 
-    fn random_get(&mut self, _buf: GuestPtrMut<u8>, _buf_len: types::Size) -> Result<()> {
+    fn random_get(&self, _buf: GuestPtrMut<u8>, _buf_len: types::Size) -> Result<()> {
         unimplemented!("random_get")
     }
 
     fn sock_recv(
-        &mut self,
+        &self,
         _fd: types::Fd,
         _ri_data: &types::IovecArray<'_>,
         _ri_flags: types::Riflags,
@@ -310,7 +312,7 @@ impl crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
     }
 
     fn sock_send(
-        &mut self,
+        &self,
         _fd: types::Fd,
         _si_data: &types::CiovecArray<'_>,
         _si_flags: types::Siflags,
@@ -318,7 +320,7 @@ impl crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
         unimplemented!("sock_send")
     }
 
-    fn sock_shutdown(&mut self, _fd: types::Fd, _how: types::Sdflags) -> Result<()> {
+    fn sock_shutdown(&self, _fd: types::Fd, _how: types::Sdflags) -> Result<()> {
         unimplemented!("sock_shutdown")
     }
 }


### PR DESCRIPTION
This commit puts context object, i.e., the implementor of the WASI snapshot, behind a reference `&self` rather than a mutable reference `&mut self`. As suggested by @alexcrichton, this gives the implementor the possibility to determine how it handles its interior mutability.

cc @alexcrichton I'm cc'ing you in, as I cannot select you as a reviewer yet.