### PR TITLE
add a lifetime to the wiggle_runtime::GuestErrorType trait

### DIFF
--- a/crates/generate/src/lib.rs
+++ b/crates/generate/src/lib.rs
@@ -1,4 +1,4 @@
-mod config;
+pub mod config;
 mod funcs;
 mod lifetimes;
 mod module_trait;

--- a/crates/runtime/src/guest_type.rs
+++ b/crates/runtime/src/guest_type.rs
@@ -1,7 +1,7 @@
 use crate::{GuestError, GuestPtr};
 use std::mem;
 
-pub trait GuestErrorType {
+pub trait GuestErrorType<'a> {
     type Context;
     fn success() -> Self;
     fn from_error(e: GuestError, ctx: &Self::Context) -> Self;

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -9,7 +9,7 @@ wiggle::from_witx!({
 
 impl_errno!(types::Errno);
 
-impl arrays::Arrays for WasiCtx {
+impl<'a> arrays::Arrays for WasiCtx<'a> {
     fn reduce_excuses(
         &self,
         excuses: &types::ConstExcuseArray,

--- a/tests/atoms.rs
+++ b/tests/atoms.rs
@@ -9,7 +9,7 @@ wiggle::from_witx!({
 
 impl_errno!(types::Errno);
 
-impl atoms::Atoms for WasiCtx {
+impl<'a> atoms::Atoms for WasiCtx<'a> {
     fn int_float_args(&self, an_int: u32, an_float: f32) -> Result<(), types::Errno> {
         println!("INT FLOAT ARGS: {} {}", an_int, an_float);
         Ok(())

--- a/tests/flags.rs
+++ b/tests/flags.rs
@@ -10,7 +10,7 @@ wiggle::from_witx!({
 
 impl_errno!(types::Errno);
 
-impl flags::Flags for WasiCtx {
+impl<'a> flags::Flags for WasiCtx<'a> {
     fn configure_car(
         &self,
         old_config: types::CarConfig,

--- a/tests/handles.rs
+++ b/tests/handles.rs
@@ -11,7 +11,7 @@ wiggle::from_witx!({
 
 impl_errno!(types::Errno);
 
-impl handle_examples::HandleExamples for WasiCtx {
+impl<'a> handle_examples::HandleExamples for WasiCtx<'a> {
     fn fd_create(&self) -> Result<types::Fd, types::Errno> {
         Ok(types::Fd::from(FD_VAL))
     }

--- a/tests/ints.rs
+++ b/tests/ints.rs
@@ -10,7 +10,7 @@ wiggle::from_witx!({
 
 impl_errno!(types::Errno);
 
-impl ints::Ints for WasiCtx {
+impl<'a> ints::Ints for WasiCtx<'a> {
     fn cookie_cutter(&self, init_cookie: types::Cookie) -> Result<types::Bool, types::Errno> {
         let res = if init_cookie == types::Cookie::START {
             types::Bool::True

--- a/tests/pointers.rs
+++ b/tests/pointers.rs
@@ -9,13 +9,13 @@ wiggle::from_witx!({
 
 impl_errno!(types::Errno);
 
-impl pointers::Pointers for WasiCtx {
-    fn pointers_and_enums<'a>(
+impl<'a> pointers::Pointers for WasiCtx<'a> {
+    fn pointers_and_enums<'b>(
         &self,
         input1: types::Excuse,
-        input2_ptr: GuestPtr<'a, types::Excuse>,
-        input3_ptr: GuestPtr<'a, types::Excuse>,
-        input4_ptr_ptr: GuestPtr<'a, GuestPtr<'a, types::Excuse>>,
+        input2_ptr: GuestPtr<'b, types::Excuse>,
+        input3_ptr: GuestPtr<'b, types::Excuse>,
+        input4_ptr_ptr: GuestPtr<'b, GuestPtr<'b, types::Excuse>>,
     ) -> Result<(), types::Errno> {
         println!("BAZ input1 {:?}", input1);
         let input2: types::Excuse = input2_ptr.read().map_err(|e| {

--- a/tests/strings.rs
+++ b/tests/strings.rs
@@ -9,7 +9,7 @@ wiggle::from_witx!({
 
 impl_errno!(types::Errno);
 
-impl strings::Strings for WasiCtx {
+impl<'a> strings::Strings for WasiCtx<'a> {
     fn hello_string(&self, a_string: &GuestPtr<str>) -> Result<u32, types::Errno> {
         let mut bc = GuestBorrows::new();
         let s = a_string.as_raw(&mut bc).expect("should be valid string");

--- a/tests/structs.rs
+++ b/tests/structs.rs
@@ -9,7 +9,7 @@ wiggle::from_witx!({
 
 impl_errno!(types::Errno);
 
-impl structs::Structs for WasiCtx {
+impl<'a> structs::Structs for WasiCtx<'a> {
     fn sum_of_pair(&self, an_pair: &types::PairInts) -> Result<i64, types::Errno> {
         Ok(an_pair.first as i64 + an_pair.second as i64)
     }
@@ -42,11 +42,11 @@ impl structs::Structs for WasiCtx {
         })
     }
 
-    fn return_pair_of_ptrs<'a>(
+    fn return_pair_of_ptrs<'b>(
         &self,
-        first: GuestPtr<'a, i32>,
-        second: GuestPtr<'a, i32>,
-    ) -> Result<types::PairIntPtrs<'a>, types::Errno> {
+        first: GuestPtr<'b, i32>,
+        second: GuestPtr<'b, i32>,
+    ) -> Result<types::PairIntPtrs<'b>, types::Errno> {
         Ok(types::PairIntPtrs { first, second })
     }
 }

--- a/tests/union.rs
+++ b/tests/union.rs
@@ -31,7 +31,7 @@ fn mult_zero_nan(a: f32, b: u32) -> f32 {
     }
 }
 
-impl union_example::UnionExample for WasiCtx {
+impl<'a> union_example::UnionExample for WasiCtx<'a> {
     fn get_tag(&self, u: &types::Reason) -> Result<types::Excuse, types::Errno> {
         println!("GET TAG: {:?}", u);
         match u {

--- a/tests/wasi.rs
+++ b/tests/wasi.rs
@@ -8,21 +8,21 @@ wiggle::from_witx!({
 
 type Result<T> = std::result::Result<T, types::Errno>;
 
-impl GuestErrorType for types::Errno {
-    type Context = WasiCtx;
+impl<'a> GuestErrorType<'a> for types::Errno {
+    type Context = WasiCtx<'a>;
 
     fn success() -> types::Errno {
         types::Errno::Success
     }
 
-    fn from_error(e: GuestError, ctx: &WasiCtx) -> types::Errno {
+    fn from_error(e: GuestError, ctx: &Self::Context) -> types::Errno {
         eprintln!("GUEST ERROR: {:?}", e);
         ctx.guest_errors.borrow_mut().push(e);
         types::Errno::Io
     }
 }
 
-impl crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
+impl<'a> crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx<'a> {
     fn args_get(&self, _argv: GuestPtr<GuestPtr<u8>>, _argv_buf: GuestPtr<u8>) -> Result<()> {
         unimplemented!("args_get")
     }


### PR DESCRIPTION
wiggle_test::WasiCtx gets one to show it works.

We need this lifetime parameter for Lucet integration.

Tacked on another minor PR that exposes the wiggle_generate config parsing in a way that we can extend the macro in Lucet.